### PR TITLE
fix: hotspot icon out of copy

### DIFF
--- a/src/pages/HotspotView.js
+++ b/src/pages/HotspotView.js
@@ -227,19 +227,19 @@ class HotspotView extends Component {
                     {hotspot.name}
                   </Title>
                   <Tooltip placement="bottom" title="Hotspot Network Address">
+                    <img
+                      src={HotspotImg}
+                      style={{
+                        height: 15,
+                        marginRight: 5,
+                        position: 'relative',
+                        top: '-2px',
+                      }}
+                    />
                     <Text
                       copyable
                       style={{ fontFamily: 'monospace', color: '#8283B2' }}
                     >
-                      <img
-                        src={HotspotImg}
-                        style={{
-                          height: 15,
-                          marginRight: 5,
-                          position: 'relative',
-                          top: '-2px',
-                        }}
-                      />
                       {hotspot.address}
                     </Text>
                   </Tooltip>


### PR DESCRIPTION
We move the hotspot icon out of copy, which resolves #16.