### PR TITLE
Disable "Next Block" button for current block

### DIFF
--- a/src/components/AppLayout/BlockHeight.js
+++ b/src/components/AppLayout/BlockHeight.js
@@ -3,47 +3,29 @@ import { Typography, Tooltip, Spin } from 'antd'
 import { CodeSandboxOutlined } from '@ant-design/icons'
 import Client from '@helium/http'
 import Block from '../../images/block.svg'
+import withBlockHeight from '../withBlockHeight'
 
 class BlockHeight extends Component {
-  state = {
-    height: 0,
-    loading: true,
-  }
-
-  componentDidMount() {
-    this.client = new Client()
-    this.loadBlockHeight()
-    window.setInterval(this.loadBlockHeight, 30000)
-  }
-
-  loadBlockHeight = async () => {
-    try {
-      const blocks = await this.client.blocks.list()
-      const [{ height }] = await blocks.take(1)
-      this.setState({ height, loading: false })
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
   render() {
-    const { height, loading } = this.state
     return (
       <Tooltip placement="bottomRight" title="Current Block Height">
         <a
-          href={`/blocks/${height}`}
+          href={`/blocks/${this.props.height}`}
           style={{ minWidth: 127, textAlign: 'center', fontSize: 17 }}
         >
           <img
             style={{ marginRight: 5, position: 'relative', top: '-1px' }}
             src={Block}
+            alt=""
           />
-          {!loading && height.toLocaleString()}
-          {loading && <Spin size="small" />}
+          {!this.props.heightLoading && this.props.height.toLocaleString()}
+          {this.props.heightLoading && <Spin size="small" />}
         </a>
       </Tooltip>
     )
   }
 }
 
-export default BlockHeight
+const WrappedBlockHeight = withBlockHeight(BlockHeight)
+
+export default WrappedBlockHeight

--- a/src/components/withBlockHeight.js
+++ b/src/components/withBlockHeight.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import Client from '@helium/http'
+
+const withBlockHeight = (WrappedComponent) => {
+  class BlockHeight extends React.Component {
+    state = {
+      height: 0,
+      heightLoading: true,
+    }
+
+    componentDidMount() {
+      this.client = new Client()
+      this.loadBlockHeight()
+      window.setInterval(this.loadBlockHeight, 30000)
+    }
+
+    loadBlockHeight = async () => {
+      try {
+        const blocks = await this.client.blocks.list()
+        const [{ height }] = await blocks.take(1)
+        this.setState({ height, heightLoading: false })
+      } catch (error) {
+        console.log(error)
+      }
+    }
+
+    render() {
+      const { height, heightLoading } = this.state
+
+      return (
+        <WrappedComponent
+          {...this.props}
+          height={height}
+          heightLoading={heightLoading}
+        />
+      )
+    }
+  }
+  return BlockHeight
+}
+
+export default withBlockHeight

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -26,6 +26,7 @@ const initialState = {
   txns: [],
   loading: true,
   hasMore: true,
+  height: 0,
 }
 
 class BlockView extends Component {
@@ -50,7 +51,9 @@ class BlockView extends Component {
       this.client.block(hash).transactions.list(),
     ])
     this.txnList = txnList
-    this.setState({ block, loading: false })
+    const blocks = await this.client.blocks.list()
+    const [{ height }] = await blocks.take(1)
+    this.setState({ block, height, loading: false })
     this.loadMoreTxns()
   }
 
@@ -62,7 +65,7 @@ class BlockView extends Component {
   }
 
   render() {
-    const { block, loading, txns, hasMore } = this.state
+    const { block, loading, txns, hasMore, height } = this.state
 
     const filterTxns = () => {
       const res = []
@@ -174,9 +177,17 @@ class BlockView extends Component {
                   {block.transactionCount} transactions
                 </h3>
               )}
-              <a href={`/blocks/${block.height + 1}`} className="button">
-                Next Block <ForwardOutlined style={{ marginRight: '-6px' }} />
-              </a>
+              {block.height < height ? (
+                <a href={`/blocks/${block.height + 1}`} className="button">
+                  Next Block <ForwardOutlined style={{ marginRight: '-6px' }} />
+                </a>
+              ) : (
+                <span
+                  style={{
+                    width: '139.5px', // the width the "Next block" button takes up
+                  }}
+                />
+              )}
             </div>
           </div>
         </Content>

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -9,6 +9,7 @@ import LoadMoreButton from '../components/LoadMoreButton'
 import classNames from 'classnames'
 import Fade from 'react-reveal/Fade'
 import PieChart from '../components/PieChart'
+import withBlockHeight from '../components/withBlockHeight'
 
 import {
   BackwardOutlined,
@@ -26,7 +27,6 @@ const initialState = {
   txns: [],
   loading: true,
   hasMore: true,
-  height: 0,
 }
 
 class BlockView extends Component {
@@ -51,9 +51,7 @@ class BlockView extends Component {
       this.client.block(hash).transactions.list(),
     ])
     this.txnList = txnList
-    const blocks = await this.client.blocks.list()
-    const [{ height }] = await blocks.take(1)
-    this.setState({ block, height, loading: false })
+    this.setState({ block, loading: false })
     this.loadMoreTxns()
   }
 
@@ -177,7 +175,7 @@ class BlockView extends Component {
                   {block.transactionCount} transactions
                 </h3>
               )}
-              {block.height < height ? (
+              {block.height < this.props.height ? (
                 <a href={`/blocks/${block.height + 1}`} className="button">
                   Next Block <ForwardOutlined style={{ marginRight: '-6px' }} />
                 </a>
@@ -236,4 +234,6 @@ class BlockView extends Component {
   }
 }
 
-export default BlockView
+const WrappedBlockView = withBlockHeight(BlockView)
+
+export default WrappedBlockView


### PR DESCRIPTION
I tried a couple of other approaches before settling on this one:

- conditionally setting `pointer-events: none` when `block.height === height` (and also setting `cursor: not-allowed`, but that gets cancelled out by `pointer-events: none`)
- conditionally setting the `onClick={(e) => e.preventDefault()}`

A combination of the above two might work nicely on desktop, but I figured neither of those would be ideal for mobile, because they would rely on hover effects, or custom "disabled" button styling (which I'm not sure we have) in order for the user to know the button is disabled.

So instead I added a `<span/>` that takes up the same width as the button (so as not to push the other elements in the middle of that row to the right), and made the Next Block button just not show up for the current block page.

Happy to do it the other way though (with a "disabled"-styled button) if anyone thinks that's better!

GIF of how it looks:
![2020-10-05 11 53 29](https://user-images.githubusercontent.com/10648471/95119949-a20c2a00-0701-11eb-9b99-d9cb3309bebe.gif)
