### PR TITLE
Fix for PoC transaction datarate display

### DIFF
--- a/src/pages/TxnView.js
+++ b/src/pages/TxnView.js
@@ -115,10 +115,25 @@ class TxnView extends Component {
                       </a>
                       {p.receipt && p.receipt.origin === 'radio' ? (
                         <small>
-                          {' '}
-                          (received at RSSI {p.receipt.signal}dBm, SNR{' '}
-                          {p.receipt.snr.toFixed(2)}dB,{' '}
-                          {String.fromCharCode.apply(null, p.receipt.datarate)})
+                          {` (received at RSSI ${
+                            p.receipt.signal
+                          }dBm, SNR ${p.receipt.snr.toFixed(2)}dB${
+                            p.receipt !== null
+                              ? Array.isArray(p.receipt.datarate)
+                                ? `${
+                                    p.receipt.datarate.length > 0
+                                      ? `, ${String.fromCharCode.apply(
+                                          null,
+                                          p.receipt.datarate,
+                                        )}`
+                                      : ``
+                                  }`
+                                : `${
+                                    p.receipt.datarate !== null &&
+                                    `, ${p.receipt.datarate} `
+                                  }`
+                              : ``
+                          })`}
                         </small>
                       ) : (
                         <span></span>
@@ -136,10 +151,24 @@ class TxnView extends Component {
                                 <a href={'/hotspots/' + w.gateway}>
                                   {animalHash(w.gateway)}
                                 </a>
-                                - witnessed at RSSI {w.signal}dBm, SNR{' '}
-                                {w.snr.toFixed(2)}dB,{' '}
-                                {String.fromCharCode.apply(null, w.datarate)} (
-                                {w.is_valid ? 'valid' : 'invalid'})
+                                {`- witnessed at RSSI ${
+                                  w.signal
+                                }dBm, SNR ${w.snr.toFixed(2)}dB${
+                                  Array.isArray(w.datarate)
+                                    ? `${
+                                        w.datarate.length > 0
+                                          ? `, ${String.fromCharCode.apply(
+                                              null,
+                                              w.datarate,
+                                            )}`
+                                          : ``
+                                      } `
+                                    : `${
+                                        w.datarate !== null &&
+                                        `, ${w.datarate} `
+                                      }`
+                                }
+                                  (${w.is_valid ? 'valid' : 'invalid'})`}
                               </small>
                             </span>
                           </div>


### PR DESCRIPTION
The datarate value was coming in as a byte array previously, and now it comes in as a string. But since some pages (e.g. https://explorer.helium.com/txns/WSm1CdX806fDQ2ZBZtnupoerZJPpanMzNKDH9oBN6mk ) still return the byte array, I made it so it checks which format the value is returned in and handles it in the appropriate way.

The resulting code isn't the easiest to read at first, but it felt like a good opportunity to make use of ES6 template literals :)

Basically what it's doing is this:

If the datarate value is returned as an array, but that array is empty, just don't show that value, and don't show the comma and extra space.

If it's returned as an array of bytes, handle it the way it was handled previously (with a comma and a space before it).

If it's returned as a non-null-value string, just display the string (with a comma and a space before it).