### PR TITLE
Responsiveness improvements for block detail pages

### DIFF
--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -222,6 +222,26 @@ hr {
   font-size: 17px;
 }
 
+.content-container {
+  padding: 60px 20px 30px 20px;
+}
+
+.flex-responsive {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  /* padding: 0 calc(20px * 2); */
+
+  /* max-width: calc(850px + 40px); */
+}
+
+@media screen and (max-width: 890px) {
+  /* .flex-responsive {
+    padding: 0 20px;
+  } */
+}
 @media screen and (max-width: 640px) {
   .logo-container {
     margin-right: 12px;
@@ -241,5 +261,11 @@ hr {
   }
   .header {
     padding: 12px;
+  }
+  .content-container {
+    padding: 30px 12px 30px 12px;
+  }
+  .flex-responsive {
+    flex-direction: column;
   }
 }

--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -243,16 +243,42 @@ hr {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+}
 
-  /* padding: 0 calc(20px * 2); */
+.block-view-clock-icon {
+  margin-left: 16px;
+}
+.block-view-summary-info {
+  order: 2;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+.block-view-prev-button {
+  order: 1;
+  min-width: 175px;
+  text-align: center;
+}
+.block-view-next-button {
+  order: 3;
+  min-width: 175px;
+  text-align: center;
+}
 
-  /* max-width: calc(850px + 40px); */
+.block-view-summary-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  flex-direction: row;
 }
 
 @media screen and (max-width: 890px) {
-  /* .flex-responsive {
-    padding: 0 20px;
-  } */
+  .block-view-summary-info {
+    flex-direction: column;
+  }
+  .block-view-clock-icon {
+    margin-left: 0px;
+  }
 }
 @media screen and (max-width: 640px) {
   .logo-container {
@@ -279,5 +305,20 @@ hr {
   }
   .flex-responsive {
     flex-direction: column;
+  }
+  .block-view-summary-info {
+    width: 100%;
+    order: 1;
+    padding-bottom: 30px;
+  }
+  .block-view-prev-button {
+    order: 2;
+    min-width: 49%;
+    padding: 6px;
+  }
+  .block-view-next-button {
+    min-width: 170px;
+    min-width: 49%;
+    order: 3;
   }
 }

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -181,7 +181,7 @@ class BlockView extends Component {
                     <CheckCircleOutlined
                       style={{
                         color: '#29D391',
-                        marginRight: 4,
+                        marginRight: 8,
                       }}
                     />
                     {block.transactionCount} transactions

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -111,7 +111,6 @@ class BlockView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            // padding: '60px 0 30px',
           }}
         >
           <div
@@ -119,7 +118,9 @@ class BlockView extends Component {
             className="content-container"
           >
             <div className="flex-responsive">
-              <div>
+              <div
+                style={{ paddingBottom: 30, paddingRight: 30, width: '100%' }}
+              >
                 <h3>Block</h3>
                 <Title
                   style={{
@@ -135,7 +136,11 @@ class BlockView extends Component {
                 <div>
                   <Text
                     copyable
-                    style={{ color: '#6A6B93', fontFamily: 'monospace' }}
+                    style={{
+                      color: '#6A6B93',
+                      fontFamily: 'monospace',
+                      wordBreak: 'break-all',
+                    }}
                   >
                     {block.hash}
                   </Text>
@@ -148,39 +153,51 @@ class BlockView extends Component {
             </div>
 
             <hr />
-            <div className="flexwrapper">
-              <a href={`/blocks/${block.height - 1}`} className="button">
+            <div className="block-view-summary-container">
+              <a
+                href={`/blocks/${block.height - 1}`}
+                className="button block-view-prev-button"
+              >
                 <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous
                 Block
               </a>
-
-              <h3>
-                <ClockCircleOutlined
-                  style={{ color: '#FFC769', marginRight: 4 }}
-                />{' '}
-                <Timestamp
-                  date={
-                    block.hash === 'La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI'
-                      ? 1564436673
-                      : block.time
-                  }
-                />
-              </h3>
-
-              {txns.length > 0 && (
+              <span className="block-view-summary-info">
                 <h3>
-                  <CheckCircleOutlined
-                    style={{ color: '#29D391', marginRight: 4 }}
+                  <ClockCircleOutlined
+                    style={{ color: '#FFC769', marginRight: 4 }}
                   />{' '}
-                  {block.transactionCount} transactions
+                  <Timestamp
+                    date={
+                      block.hash ===
+                      'La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI'
+                        ? 1564436673
+                        : block.time
+                    }
+                  />
                 </h3>
-              )}
+
+                {txns.length > 0 && (
+                  <h3 className="block-view-clock-icon">
+                    <CheckCircleOutlined
+                      style={{
+                        color: '#29D391',
+                        marginRight: 4,
+                      }}
+                    />
+                    {block.transactionCount} transactions
+                  </h3>
+                )}
+              </span>
               {block.height < this.props.height ? (
-                <a href={`/blocks/${block.height + 1}`} className="button">
+                <a
+                  href={`/blocks/${block.height + 1}`}
+                  className="button block-view-next-button"
+                >
                   Next Block <ForwardOutlined style={{ marginRight: '-6px' }} />
                 </a>
               ) : (
                 <span
+                  className="block-view-next-button"
                   style={{
                     width: '139.5px', // the width the "Next block" button takes up
                   }}

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -114,11 +114,14 @@ class BlockView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            padding: '60px 0 30px',
+            // padding: '60px 0 30px',
           }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850 }}>
-            <div className="flexwrapper">
+          <div
+            style={{ margin: '0 auto', maxWidth: 850 + 40 }}
+            className="content-container"
+          >
+            <div className="flex-responsive">
               <div>
                 <h3>Block</h3>
                 <Title


### PR DESCRIPTION
This PR is for the block view page (e.g: https://explorer.helium.com/blocks/534672 )

This should make it much more friendly for mobile users. Here's a screen recording of how it looks across different breakpoints: 
![2020-10-07 17 05 15](https://user-images.githubusercontent.com/10648471/95400436-7171ef00-08bf-11eb-97e1-2cf40ba4dcb9.gif)

And a simpler before and after:

# Before: 
![Screen Shot 2020-10-07 at 5 03 30 PM](https://user-images.githubusercontent.com/10648471/95400513-9e260680-08bf-11eb-8918-8c5d964f7371.png)

# After:
![Screen Shot 2020-10-07 at 5 03 35 PM](https://user-images.githubusercontent.com/10648471/95400523-a41be780-08bf-11eb-88e9-ae72c526affe.png)
