### PR TITLE
Make homepage hero section more responsive

### DIFF
--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -234,6 +234,12 @@ hr {
   font-size: 17px;
 }
 
+.summary-header {
+  margin-bottom: 100px;
+}
+.summary-header > .ant-row > .ant-col-lg-12 {
+  padding: 16px 24px;
+}
 .content-container {
   padding: 60px 20px 30px 20px;
 }
@@ -296,6 +302,9 @@ hr {
     height: 10px;
     margin-left: 12px;
     flex-direction: column;
+  }
+  .summary-header {
+    margin-bottom: 0px;
   }
   .header {
     padding: 12px;

--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -89,11 +89,13 @@ class Index extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            padding: '60px 0 20px',
           }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850 }}>
-            <div className="flexwrapper">
+          <div
+            style={{ margin: '0 auto', maxWidth: 850 + 40 }}
+            className="content-container"
+          >
+            <div className="flex-responsive">
               <Title
                 style={{
                   margin: '0px 0 40px',
@@ -113,9 +115,8 @@ class Index extends Component {
                 style={{
                   background: '#3F416D',
                   borderRadius: 10,
-                  padding: '16px 24px',
-                  marginBottom: 100,
                 }}
+                className="summary-header"
               >
                 <Row>
                   <Col lg={12}>
@@ -149,6 +150,7 @@ class Index extends Component {
                       {Math.round(blockTime * 10) / 10}s
                     </p>
                   </Col>
+
                   <Col lg={12}>
                     <h3
                       style={{


### PR DESCRIPTION
Fixes #45 

Makes the home page stat summary section more mobile friendly, with some adjusted padding, centering the title, etc.

# Before:
![image](https://user-images.githubusercontent.com/10648471/95525280-89617580-0988-11eb-8340-0ef92a87b4ac.png)

# After:
![image](https://user-images.githubusercontent.com/10648471/95525299-92524700-0988-11eb-838c-c59a5acb5923.png)