### PR TITLE
Make transaction, hotspot, account page headers more responsive

### DIFF
--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -222,6 +222,26 @@ hr {
   font-size: 17px;
 }
 
+.content-container {
+  padding: 60px 20px 30px 20px;
+}
+
+.flex-responsive {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  /* padding: 0 calc(20px * 2); */
+
+  /* max-width: calc(850px + 40px); */
+}
+
+@media screen and (max-width: 890px) {
+  /* .flex-responsive {
+    padding: 0 20px;
+  } */
+}
 @media screen and (max-width: 640px) {
   .logo-container {
     margin-right: 12px;
@@ -241,5 +261,11 @@ hr {
   }
   .header {
     padding: 12px;
+  }
+  .content-container {
+    padding: 30px 12px 30px 12px;
+  }
+  .flex-responsive {
+    flex-direction: column;
   }
 }

--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -243,6 +243,24 @@ hr {
 .content-container {
   padding: 60px 20px 30px 20px;
 }
+.content-container-hotspot-view {
+  padding: 0px 20px 50px 20px;
+}
+.content-container-txn-view {
+  padding: 60px 20px 30px 20px;
+}
+.content-container-account-view {
+  padding: 80px 20px 50px 20px;
+}
+.content-container-hotspot-view > .mapboxgl-map {
+  height: 400px;
+}
+.hotspot-name > h1 {
+  line-height: 0.7;
+}
+.line-break-only-at-small {
+  display: none;
+}
 
 .flex-responsive {
   display: flex;
@@ -311,6 +329,21 @@ hr {
   }
   .content-container {
     padding: 30px 12px 30px 12px;
+  }
+  .content-container-account-view {
+    padding: 50px 20px 20px 20px;
+  }
+  .content-container-hotspot-view {
+    padding: 20px;
+  }
+  .content-container-hotspot-view > .mapboxgl-map {
+    height: 200px;
+  }
+  .hotspot-name > h1 {
+    line-height: 1;
+  }
+  .line-break-only-at-small {
+    display: block;
   }
   .flex-responsive {
     flex-direction: column;

--- a/src/Explorer.css
+++ b/src/Explorer.css
@@ -243,16 +243,42 @@ hr {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+}
 
-  /* padding: 0 calc(20px * 2); */
+.block-view-clock-icon {
+  margin-left: 16px;
+}
+.block-view-summary-info {
+  order: 2;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+.block-view-prev-button {
+  order: 1;
+  min-width: 175px;
+  text-align: center;
+}
+.block-view-next-button {
+  order: 3;
+  min-width: 175px;
+  text-align: center;
+}
 
-  /* max-width: calc(850px + 40px); */
+.block-view-summary-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  flex-direction: row;
 }
 
 @media screen and (max-width: 890px) {
-  /* .flex-responsive {
-    padding: 0 20px;
-  } */
+  .block-view-summary-info {
+    flex-direction: column;
+  }
+  .block-view-clock-icon {
+    margin-left: 0px;
+  }
 }
 @media screen and (max-width: 640px) {
   .logo-container {
@@ -279,5 +305,20 @@ hr {
   }
   .flex-responsive {
     flex-direction: column;
+  }
+  .block-view-summary-info {
+    width: 100%;
+    order: 1;
+    padding-bottom: 30px;
+  }
+  .block-view-prev-button {
+    order: 2;
+    min-width: 49%;
+    padding: 6px;
+  }
+  .block-view-next-button {
+    min-width: 170px;
+    min-width: 49%;
+    order: 3;
   }
 }

--- a/src/pages/AccountView.js
+++ b/src/pages/AccountView.js
@@ -69,11 +69,17 @@ class AccountView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            padding: '80px 0 50px',
             overflowX: 'hidden',
           }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850, textAlign: 'center' }}>
+          <div
+            style={{
+              margin: '0 auto',
+              maxWidth: 850 + 40,
+              textAlign: 'center',
+            }}
+            className="content-container-account-view"
+          >
             <Fade top>
               <div
                 style={{
@@ -94,7 +100,12 @@ class AccountView extends Component {
                 code
                 level={4}
                 copyable
-                style={{ color: 'white', marginBottom: 0, fontWeight: 300 }}
+                style={{
+                  color: 'white',
+                  marginBottom: 0,
+                  fontWeight: 300,
+                  wordBreak: 'break-all',
+                }}
               >
                 {account.address}
               </Title>
@@ -168,7 +179,7 @@ class AccountView extends Component {
           }}
         >
           <HotspotsList hotspots={hotspots} loading={loading} />
-          <ActivityList type="account" address={address} title={'Hello'} hotspots={hotspots} />
+          <ActivityList type="account" address={address} hotspots={hotspots} />
         </Content>
       </AppLayout>
     )

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -181,7 +181,7 @@ class BlockView extends Component {
                     <CheckCircleOutlined
                       style={{
                         color: '#29D391',
-                        marginRight: 4,
+                        marginRight: 8,
                       }}
                     />
                     {block.transactionCount} transactions

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -111,7 +111,6 @@ class BlockView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            // padding: '60px 0 30px',
           }}
         >
           <div
@@ -119,7 +118,9 @@ class BlockView extends Component {
             className="content-container"
           >
             <div className="flex-responsive">
-              <div>
+              <div
+                style={{ paddingBottom: 30, paddingRight: 30, width: '100%' }}
+              >
                 <h3>Block</h3>
                 <Title
                   style={{
@@ -135,7 +136,11 @@ class BlockView extends Component {
                 <div>
                   <Text
                     copyable
-                    style={{ color: '#6A6B93', fontFamily: 'monospace' }}
+                    style={{
+                      color: '#6A6B93',
+                      fontFamily: 'monospace',
+                      wordBreak: 'break-all',
+                    }}
                   >
                     {block.hash}
                   </Text>
@@ -148,39 +153,51 @@ class BlockView extends Component {
             </div>
 
             <hr />
-            <div className="flexwrapper">
-              <a href={`/blocks/${block.height - 1}`} className="button">
+            <div className="block-view-summary-container">
+              <a
+                href={`/blocks/${block.height - 1}`}
+                className="button block-view-prev-button"
+              >
                 <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous
                 Block
               </a>
-
-              <h3>
-                <ClockCircleOutlined
-                  style={{ color: '#FFC769', marginRight: 4 }}
-                />{' '}
-                <Timestamp
-                  date={
-                    block.hash === 'La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI'
-                      ? 1564436673
-                      : block.time
-                  }
-                />
-              </h3>
-
-              {txns.length > 0 && (
+              <span className="block-view-summary-info">
                 <h3>
-                  <CheckCircleOutlined
-                    style={{ color: '#29D391', marginRight: 4 }}
+                  <ClockCircleOutlined
+                    style={{ color: '#FFC769', marginRight: 4 }}
                   />{' '}
-                  {block.transactionCount} transactions
+                  <Timestamp
+                    date={
+                      block.hash ===
+                      'La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI'
+                        ? 1564436673
+                        : block.time
+                    }
+                  />
                 </h3>
-              )}
+
+                {txns.length > 0 && (
+                  <h3 className="block-view-clock-icon">
+                    <CheckCircleOutlined
+                      style={{
+                        color: '#29D391',
+                        marginRight: 4,
+                      }}
+                    />
+                    {block.transactionCount} transactions
+                  </h3>
+                )}
+              </span>
               {block.height < this.props.height ? (
-                <a href={`/blocks/${block.height + 1}`} className="button">
+                <a
+                  href={`/blocks/${block.height + 1}`}
+                  className="button block-view-next-button"
+                >
                   Next Block <ForwardOutlined style={{ marginRight: '-6px' }} />
                 </a>
               ) : (
                 <span
+                  className="block-view-next-button"
                   style={{
                     width: '139.5px', // the width the "Next block" button takes up
                   }}

--- a/src/pages/BlockView.js
+++ b/src/pages/BlockView.js
@@ -114,11 +114,14 @@ class BlockView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            padding: '60px 0 30px',
+            // padding: '60px 0 30px',
           }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850 }}>
-            <div className="flexwrapper">
+          <div
+            style={{ margin: '0 auto', maxWidth: 850 + 40 }}
+            className="content-container"
+          >
+            <div className="flex-responsive">
               <div>
                 <h3>Block</h3>
                 <Title

--- a/src/pages/HotspotView.js
+++ b/src/pages/HotspotView.js
@@ -152,7 +152,10 @@ class HotspotView extends Component {
         <Content
           style={{ marginTop: 0, background: '#27284B', padding: '0px 0 0px' }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850 }}>
+          <div
+            style={{ margin: '0 auto', maxWidth: 850 + 40 }}
+            className="content-container-hotspot-view"
+          >
             <Mapbox
               style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
               container="map"
@@ -161,7 +164,6 @@ class HotspotView extends Component {
                 hotspot.lat ? hotspot.lat : 0,
               ]}
               containerStyle={{
-                height: '400px',
                 width: '100%',
               }}
               zoom={[11]}
@@ -231,7 +233,8 @@ class HotspotView extends Component {
                   width: '100%',
                   justifyContent: 'flex-start',
                   alignItems: 'flex-start',
-                  marginBottom: 50,
+                  // marginBottom: 50,
+                  paddingRight: 20,
                 }}
               >
                 <div style={{ width: '100%' }}>
@@ -256,18 +259,19 @@ class HotspotView extends Component {
                       </h3>
                     </Tooltip>
                   </Fade>
-                  <Title
-                    style={{
-                      color: 'white',
-                      fontSize: 52,
-                      marginTop: 0,
-                      lineHeight: 0.7,
-                      letterSpacing: '-2px',
-                      marginBottom: 17,
-                    }}
-                  >
-                    {hotspot.name}
-                  </Title>
+                  <span className="hotspot-name">
+                    <Title
+                      style={{
+                        color: 'white',
+                        fontSize: 52,
+                        marginTop: 0,
+                        letterSpacing: '-2px',
+                        marginBottom: 17,
+                      }}
+                    >
+                      {hotspot.name}
+                    </Title>
+                  </span>
                   <Tooltip placement="bottom" title="Hotspot Network Address">
                     <img
                       src={HotspotImg}
@@ -281,7 +285,11 @@ class HotspotView extends Component {
                     />
                     <Text
                       copyable
-                      style={{ fontFamily: 'monospace', color: '#8283B2' }}
+                      style={{
+                        fontFamily: 'monospace',
+                        color: '#8283B2',
+                        wordBreak: 'break-all',
+                      }}
                     >
                       {hotspot.address}
                     </Text>
@@ -294,8 +302,13 @@ class HotspotView extends Component {
           <div className="bottombar">
             <Content style={{ maxWidth: 850, margin: '0 auto' }}>
               <p style={{ color: 'white', margin: 0 }}>
-                Owned by:{' '}
-                <a href={'/accounts/' + hotspot.owner}>{hotspot.owner}</a>
+                Owned by: <br className="line-break-only-at-small" />
+                <a
+                  style={{ wordBreak: 'break-all' }}
+                  href={'/accounts/' + hotspot.owner}
+                >
+                  {hotspot.owner}
+                </a>
               </p>
             </Content>
           </div>

--- a/src/pages/TxnView.js
+++ b/src/pages/TxnView.js
@@ -267,12 +267,14 @@ class TxnView extends Component {
           style={{
             marginTop: 0,
             background: '#27284B',
-            padding: '60px 0 30px',
           }}
         >
-          <div style={{ margin: '0 auto', maxWidth: 850 }}>
-            <div className="flexwrapper" style={{ alignItems: 'flex-start' }}>
-              <div>
+          <div
+            style={{ margin: '0 auto', maxWidth: 850 + 40 }}
+            className="content-container-txn-view"
+          >
+            <div className="flex-responsive">
+              <div style={{ paddingRight: 30, width: '100%' }}>
                 <Title
                   style={{
                     color: 'white',
@@ -286,7 +288,11 @@ class TxnView extends Component {
                 </Title>
                 <Text
                   copyable
-                  style={{ color: '#6A6B93', fontFamily: 'monospace' }}
+                  style={{
+                    color: '#6A6B93',
+                    fontFamily: 'monospace',
+                    wordBreak: 'break-all',
+                  }}
                 >
                   {txn.hash}
                 </Text>


### PR DESCRIPTION
Fixes #35  (or at least starts fixing it)

Some things were getting cut off in the hero sections of these pages. This PR just adds some padding at mobile screen sizes and adjusts things slightly so they look a bit nicer on a phone, and so nothing gets pushed off the page horizontally for smaller screen sizes.

Here are the affected pages:

# Transaction
## Before
![image](https://user-images.githubusercontent.com/10648471/95634766-7d84ba80-0a3f-11eb-8326-ed639286a5b3.png)

## After
![image](https://user-images.githubusercontent.com/10648471/95634771-81184180-0a3f-11eb-8a28-c4a9d54090fb.png)



# Hotspot
## Before
![image](https://user-images.githubusercontent.com/10648471/95634776-85445f00-0a3f-11eb-85e2-25ef29d46151.png)

## After
![image](https://user-images.githubusercontent.com/10648471/95634788-8d9c9a00-0a3f-11eb-99ad-2862ca2a6025.png)



# Account
## Before
![image](https://user-images.githubusercontent.com/10648471/95634793-91c8b780-0a3f-11eb-9d36-523215171ab3.png)

## After
![image](https://user-images.githubusercontent.com/10648471/95634798-968d6b80-0a3f-11eb-8fcd-6f9b1b1cb3a3.png)
