### PR TITLE
Fix witness loading bug on hotspot page

### DIFF
--- a/components/PocMapbox.js
+++ b/components/PocMapbox.js
@@ -78,7 +78,6 @@ const styles = {
 }
 
 const PocMapbox = ({ path, showWitnesses }) => {
-  console.log(path)
   return (
     <Mapbox
       style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}

--- a/components/PocMapbox.js
+++ b/components/PocMapbox.js
@@ -78,13 +78,22 @@ const styles = {
 }
 
 const PocMapbox = ({ path, showWitnesses }) => {
+  console.log(path)
   return (
     <Mapbox
       style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
       container="map"
       center={[
-        path[0].challengee_lon ? path[0].challengee_lon : 0,
-        path[0].challengee_lat ? path[0].challengee_lat : 0,
+        path[0].challengee_lon
+          ? path[0].challengee_lon
+          : path[0].challengeeLon
+          ? path[0].challengeeLon
+          : 0,
+        path[0].challengee_lat
+          ? path[0].challengee_lat
+          : path[0].challengeeLat
+          ? path[0].challengeeLat
+          : 0,
       ]}
       containerStyle={{
         height: '600px',
@@ -108,8 +117,16 @@ const PocMapbox = ({ path, showWitnesses }) => {
               }
               anchor="center"
               coordinates={[
-                p.challengee_lon ? p.challengee_lon : 0,
-                p.challengee_lat ? p.challengee_lat : 0,
+                p.challengee_lon
+                  ? p.challengee_lon
+                  : p.challengeeLon
+                  ? p.challengeeLon
+                  : 0,
+                p.challengee_lat
+                  ? p.challengee_lat
+                  : p.challengeeLat
+                  ? p.challengeeLat
+                  : 0,
               ]}
             >
               <span style={{ color: 'white', fontSize: '8px' }}>{idx + 1}</span>
@@ -129,11 +146,30 @@ const PocMapbox = ({ path, showWitnesses }) => {
             >
               <Feature
                 coordinates={[
-                  [p.challengee_lon, p.challengee_lat],
+                  [
+                    p.challengee_lon
+                      ? p.challengee_lon
+                      : p.challengeeLon
+                      ? p.challengeeLon
+                      : 0,
+                    p.challengee_lat
+                      ? p.challengee_lat
+                      : p.challengeeLat
+                      ? p.challengeeLat
+                      : 0,
+                  ],
                   path[idx + 1]
                     ? [
-                        path[idx + 1].challengee_lon,
-                        path[idx + 1].challengee_lat,
+                        path[idx + 1].challengee_lon
+                          ? path[idx + 1].challengee_lon
+                          : path[idx + 1].challengeeLon
+                          ? path[idx + 1].challengeeLon
+                          : 0,
+                        path[idx + 1].challengee_lat
+                          ? path[idx + 1].challengee_lat
+                          : path[idx + 1].challengeeLat
+                          ? path[idx + 1].challengeeLat
+                          : 0,
                       ]
                     : [false],
                 ]}
@@ -173,7 +209,18 @@ const PocMapbox = ({ path, showWitnesses }) => {
                       <Feature
                         coordinates={[
                           [h3ToGeo(w.location)[1], h3ToGeo(w.location)[0]],
-                          [p.challengee_lon, p.challengee_lat],
+                          [
+                            p.challengee_lon
+                              ? p.challengee_lon
+                              : p.challengeeLon
+                              ? p.challengeeLon
+                              : 0,
+                            p.challengee_lat
+                              ? p.challengee_lat
+                              : p.challengeeLat
+                              ? p.challengeeLat
+                              : 0,
+                          ],
                         ]}
                       />
                     </Layer>

--- a/components/PocPath.js
+++ b/components/PocPath.js
@@ -37,6 +37,7 @@ class PocPath extends Component {
           <PocMapbox path={path} showWitnesses={showWitnesses} />
           <Checkbox
             onChange={this.toggleWitnesses}
+            checked={showWitnesses}
             style={{ color: 'black', float: 'right' }}
           >
             Show witnesses

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -45,6 +45,7 @@ class HotspotView extends Component {
       const { hotspotid } = this.props.router.query
       if (hotspotid !== undefined) {
         this.loadData(hotspotid)
+        this.loadWitnesses(hotspotid)
       }
     }
   }
@@ -66,6 +67,7 @@ class HotspotView extends Component {
         )
         this.setState({
           witnesses: witnessList,
+          showWitnesses: false,
         })
       })
   }
@@ -132,6 +134,7 @@ class HotspotView extends Component {
             <div style={{ textAlign: 'right', paddingTop: 6, color: 'white' }}>
               <Checkbox
                 onChange={this.toggleWitnesses}
+                checked={showWitnesses}
                 style={{ color: 'white' }}
               >
                 Show witnesses


### PR DESCRIPTION
I accidentally left out a re-fetch of the witness list when navigating between hotspot detail pages. I added it back with this PR, and also fixed an issue I was seeing with the txn detail page where the lat/lon names being returned by the API were different and defaulting to [0,0]. They seem to sometimes come back as .challengeeLon and sometimes as .challengee_lon, so it now checks for both variations.

Fixes #67 