### PR TITLE
replace score with earnings summary in accounts hotspot table

### DIFF
--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -44,10 +44,22 @@ const hotspotColumns = [
     render: (data) => <span>{formatLocation(data)}</span>,
   },
   {
-    title: 'Score',
-    dataIndex: 'score',
-    key: 'score',
-    render: (data) => round(data, 2),
+    title: 'Rewards (24h)',
+    dataIndex: 'rewards',
+    key: 'rewardsDay',
+    render: (data) => round(data.day, 2),
+  },
+  {
+    title: 'Rewards (7d)',
+    dataIndex: 'rewards',
+    key: 'rewardsWeek',
+    render: (data) => round(data.week, 2),
+  },
+  {
+    title: 'Rewards (30d)',
+    dataIndex: 'rewards',
+    key: 'rewardsMonth',
+    render: (data) => round(data.month, 2),
   },
 ]
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next-ga": "^2.3.4",
     "next-images": "^1.6.0",
     "node-fetch": "^2.6.1",
+    "qs": "^6.9.4",
     "react": "^17.0.1",
     "react-country-flag": "^2.3.0",
     "react-dom": "^17.0.1",

--- a/pages/accounts/[accountid].js
+++ b/pages/accounts/[accountid].js
@@ -9,6 +9,7 @@ import Fade from 'react-reveal/Fade'
 
 import { ClockCircleOutlined, CheckCircleOutlined } from '@ant-design/icons'
 import AccountIcon from '../../components/AccountIcon'
+import { fetchRewardsSummary } from '../../data/hotspots'
 
 const { Title } = Typography
 
@@ -139,7 +140,7 @@ function AccountView({ account, hotspots }) {
       <Content
         style={{
           margin: '0 auto',
-          maxWidth: 850,
+          maxWidth: 1000,
           paddingBottom: 100,
           marginTop: 0,
         }}
@@ -172,6 +173,8 @@ export async function getStaticProps({ params }) {
   const hotspots = []
   for await (const hotspot of list) {
     hotspot.status.gpsText = gpsLocation(hotspot.status.gps)
+    hotspot.rewards = await fetchRewardsSummary(hotspot.address)
+    delete hotspot.client
     hotspots.push(JSON.parse(JSON.stringify(hotspot)))
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11100,7 +11100,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.3:
+qs@^6.9.3, qs@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==


### PR DESCRIPTION
This replaces score which, as of HIP 16, is meaningless, with a summary of hotspot rewards. Now that we have the rewards/stats api endpoint, we'll continue to expose more of this type of information.