### PR TITLE
Add basic rewards table to hotspot page

### DIFF
--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -1,0 +1,45 @@
+const RewardSummary = ({ rewards }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: 'white',
+        padding: '36px 36px 40px 36px',
+      }}
+    >
+      <p style={{ fontFamily: 'soleil', fontSize: '16px', fontWeight: 500 }}>
+        Rewards
+      </p>
+      <div className="reward-summary-card-container">
+        <div className="reward-summary-card">
+          <p className="reward-summary-card-timeframe">24 hours</p>
+          <div className="reward-summary-card-amount-container">
+            <span className="reward-summary-number-amount">
+              {rewards.day.toFixed(2).toLocaleString()}
+            </span>
+            <span className="reward-summary-hnt-label">HNT</span>
+          </div>
+        </div>
+        <div className="reward-summary-card">
+          <p className="reward-summary-card-timeframe">7 days</p>
+          <div className="reward-summary-card-amount-container">
+            <span className="reward-summary-number-amount">
+              {rewards.week.toFixed(2).toLocaleString()}
+            </span>
+            <span className="reward-summary-hnt-label">HNT</span>
+          </div>
+        </div>
+        <div className="reward-summary-card">
+          <p className="reward-summary-card-timeframe">30 days</p>
+          <div className="reward-summary-card-amount-container">
+            <span className="reward-summary-number-amount">
+              {rewards.month.toFixed(2).toLocaleString()}
+            </span>
+            <span className="reward-summary-hnt-label">HNT</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RewardSummary

--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -1,3 +1,5 @@
+import RewardSummaryCard from './RewardSummaryCard'
+
 const RewardSummary = ({ rewards }) => {
   return (
     <div
@@ -9,34 +11,26 @@ const RewardSummary = ({ rewards }) => {
       <p style={{ fontFamily: 'soleil', fontSize: '16px', fontWeight: 500 }}>
         Rewards
       </p>
-      <div className="reward-summary-card-container">
-        <div className="reward-summary-card">
-          <p className="reward-summary-card-timeframe">24 hours</p>
-          <div className="reward-summary-card-amount-container">
-            <span className="reward-summary-number-amount">
-              {rewards.day.toFixed(2).toLocaleString()}
-            </span>
-            <span className="reward-summary-hnt-label">HNT</span>
-          </div>
-        </div>
-        <div className="reward-summary-card">
-          <p className="reward-summary-card-timeframe">7 days</p>
-          <div className="reward-summary-card-amount-container">
-            <span className="reward-summary-number-amount">
-              {rewards.week.toFixed(2).toLocaleString()}
-            </span>
-            <span className="reward-summary-hnt-label">HNT</span>
-          </div>
-        </div>
-        <div className="reward-summary-card">
-          <p className="reward-summary-card-timeframe">30 days</p>
-          <div className="reward-summary-card-amount-container">
-            <span className="reward-summary-number-amount">
-              {rewards.month.toFixed(2).toLocaleString()}
-            </span>
-            <span className="reward-summary-hnt-label">HNT</span>
-          </div>
-        </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          gridAutoRows: 'auto',
+          gridGap: '1rem',
+        }}
+      >
+        <RewardSummaryCard
+          timeframe="24 hours"
+          value={rewards.day.toFixed(2).toLocaleString()}
+        />
+        <RewardSummaryCard
+          timeframe="7 days"
+          value={rewards.week.toFixed(2).toLocaleString()}
+        />
+        <RewardSummaryCard
+          timeframe="30 days"
+          value={rewards.month.toFixed(2).toLocaleString()}
+        />
       </div>
     </div>
   )

--- a/components/Hotspots/RewardSummaryCard.js
+++ b/components/Hotspots/RewardSummaryCard.js
@@ -1,0 +1,40 @@
+const RewardSummaryCard = ({ timeframe, value }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: '#f7f7fc',
+        borderRadius: '12px',
+        minHeight: '78px',
+        padding: '12px',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          textTransform: 'uppercase',
+          fontSize: '12px',
+          color: '#6d6ea0',
+        }}
+      >
+        {timeframe}
+      </p>
+      <div>
+        <span
+          style={{
+            fontFamily: 'soleil',
+            color: '#262625',
+            fontWeight: 400,
+            fontSize: '32px',
+          }}
+        >
+          {value}
+        </span>
+        <span style={{ fontSize: '12px', marginLeft: '4px' }}>HNT</span>
+      </div>
+    </div>
+  )
+}
+
+export default RewardSummaryCard

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -25,10 +25,20 @@ export const useLatestHotspots = (initialData, count = 20) => {
   }
 }
 
+const convertDateToUTC = (date) =>
+  new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  )
+
 // TODO add this to helium-js
 export const fetchRewardsSummary = async (address) => {
   const now = new Date()
-  const nowUTC = new Date(now.getTime() + now.getTimezoneOffset() * 60000)
+  const nowUTC = convertDateToUTC(now)
   // Use UTC version of current time so that the current day's rewards get included in the API response
 
   const monthAgo = sub(now, { days: 30 })

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -41,7 +41,7 @@ export const fetchRewardsSummary = async (address) => {
   const nowUTC = convertDateToUTC(now)
   // Use UTC version of current time so that the current day's rewards get included in the API response
 
-  const monthAgo = sub(now, { days: 30 })
+  const monthAgo = sub(nowUTC, { days: 30 })
   const params = qs.stringify({
     min_time: formatISO(monthAgo),
     max_time: formatISO(nowUTC),

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -28,13 +28,13 @@ export const useLatestHotspots = (initialData, count = 20) => {
 // TODO add this to helium-js
 export const fetchRewardsSummary = async (address) => {
   const now = new Date()
-  // The API is currently returning 0 for hotspots that just started earning rewards until the range is extended beyond "now"
-  // To temporarily account for what I assume is timezone / DST weirdness, I'm setting the date range 1 day into the future
-  now.setDate(now.getDate() + 1)
+  const nowUTC = new Date(now.getTime() + now.getTimezoneOffset() * 60000)
+  // Use UTC version of current time so that the current day's rewards get included in the API response
+
   const monthAgo = sub(now, { days: 30 })
   const params = qs.stringify({
     min_time: formatISO(monthAgo),
-    max_time: formatISO(now),
+    max_time: formatISO(nowUTC),
     bucket: 'day',
   })
   const url = `https://api.helium.io/v1/hotspots/${address}/rewards/stats?${params}`

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -28,6 +28,9 @@ export const useLatestHotspots = (initialData, count = 20) => {
 // TODO add this to helium-js
 export const fetchRewardsSummary = async (address) => {
   const now = new Date()
+  // The API is currently returning 0 for hotspots that just started earning rewards until the range is extended beyond "now"
+  // To temporarily account for what I assume is timezone / DST weirdness, I'm setting the date range 1 day into the future
+  now.setDate(now.getDate() + 1)
   const monthAgo = sub(now, { days: 30 })
   const params = qs.stringify({
     min_time: formatISO(monthAgo),

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -43,17 +43,19 @@ export const fetchRewardsSummary = async (address) => {
 
   const monthAgo = sub(nowUTC, { days: 30 })
   const params = qs.stringify({
-    min_time: formatISO(monthAgo),
-    max_time: formatISO(nowUTC),
-    bucket: 'day',
+    // since the ISO format of the dates will always be a known length, substr(0, 19) will lop off the offset from the end
+    // this should only have an effect locally in the dev environment, because doing new Date() on Heroku won't have an offset
+    min_time: formatISO(monthAgo).substr(0, 19),
+    max_time: formatISO(nowUTC).substr(0, 19),
+    bucket: 'hour',
   })
   const url = `https://api.helium.io/v1/hotspots/${address}/rewards/stats?${params}`
   const response = await fetch(url)
   const { data } = await response.json()
 
   return {
-    day: data[0].total,
-    week: sumBy(data.slice(0, 6), 'total'),
+    day: sumBy(data.slice(0, 23), 'total'),
+    week: sumBy(data.slice(0, 24 * 7 - 1), 'total'),
     month: sumBy(data, 'total'),
   }
 }

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -4,6 +4,7 @@ import Client from '@helium/http'
 import algoliasearch from 'algoliasearch'
 import Fade from 'react-reveal/Fade'
 import Checklist from '../../components/Hotspots/Checklist/Checklist'
+import RewardSummary from '../../components/Hotspots/RewardSummary'
 
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
@@ -18,6 +19,8 @@ import {
   formatLocation,
 } from '../../components/Hotspots/utils'
 
+import { fetchRewardsSummary } from '../../data/hotspots'
+
 const HotspotMapbox = dynamic(
   () => import('../../components/Hotspots/HotspotMapbox'),
   {
@@ -28,7 +31,13 @@ const HotspotMapbox = dynamic(
 
 const { Title, Text } = Typography
 
-function HotspotView({ hotspot, witnesses, nearbyHotspots, activity }) {
+function HotspotView({
+  hotspot,
+  witnesses,
+  nearbyHotspots,
+  activity,
+  rewards,
+}) {
   const [showWitnesses, setShowWitnesses] = useState(true)
   const [showNearbyHotspots, setShowNearbyHotspots] = useState(true)
 
@@ -240,6 +249,16 @@ function HotspotView({ hotspot, witnesses, nearbyHotspots, activity }) {
           marginTop: 0,
         }}
       >
+        <RewardSummary rewards={rewards} />
+      </Content>
+      <Content
+        style={{
+          margin: '0 auto',
+          maxWidth: 850,
+          paddingBottom: 20,
+          marginTop: 0,
+        }}
+      >
         <WitnessesList witnesses={witnesses} />
       </Content>
 
@@ -340,6 +359,8 @@ export async function getStaticProps({ params }) {
     filters: `NOT address:${hotspotid}`,
   })
 
+  const rewards = await fetchRewardsSummary(hotspotid)
+
   // TODO convert to use @helium/http
   const witnesses = await fetch(
     `https://api.helium.io/v1/hotspots/${hotspotid}/witnesses`,
@@ -353,6 +374,7 @@ export async function getStaticProps({ params }) {
       activity: JSON.parse(JSON.stringify(hotspotActivity)),
       nearbyHotspots,
       witnesses,
+      rewards,
     },
     revalidate: 10,
   }

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -501,37 +501,6 @@ hr {
   cursor: pointer;
 }
 
-.reward-summary-card-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  grid-auto-rows: auto;
-  grid-gap: 1rem;
-}
-.reward-summary-card {
-  background-color: #f7f7fc;
-  border-radius: 12px;
-  min-height: 78px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-}
-.reward-summary-card-timeframe {
-  margin: 0;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: #6d6ea0;
-}
-.reward-summary-number-amount {
-  font-family: 'soleil';
-  color: #262625;
-  font-weight: 400;
-  font-size: 32px;
-}
-.reward-summary-hnt-label {
-  font-size: 12px;
-  margin-left: 4px;
-}
-
 @media screen and (max-width: 890px) {
   .block-view-summary-info {
     flex-direction: column;

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -429,6 +429,37 @@ hr {
   cursor: pointer;
 }
 
+.reward-summary-card-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: auto;
+  grid-gap: 1rem;
+}
+.reward-summary-card {
+  background-color: #f7f7fc;
+  border-radius: 12px;
+  min-height: 78px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+}
+.reward-summary-card-timeframe {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #6d6ea0;
+}
+.reward-summary-number-amount {
+  font-family: 'soleil';
+  color: #262625;
+  font-weight: 400;
+  font-size: 32px;
+}
+.reward-summary-hnt-label {
+  font-size: 12px;
+  margin-left: 4px;
+}
+
 @media screen and (max-width: 890px) {
   .block-view-summary-info {
     flex-direction: column;


### PR DESCRIPTION
Building off the work that added rewards breakdowns for all hotspots to the accounts page, I added the 24 hours, 7 days, and 30 days earnings numbers to the hotspot detail page.

I made a small adjustment to the `fetchRewardsSummary` function: the buckets are now in hours, so instead of the behaviour where the number only "resets" every UTC-midnight-midnight day, it'll split rewards into UTC hours, and it'll look back 24 hours (or 24 * 7 hours for the week, or 24 * 30 hours for the month). So in effect, the reward summary table values on the account page and the new reward summary cards  on each hotspot page (in this PR) will be more accurate (particularly the 24 hour value) and will effectively be a trailing / rolling number now, instead of only updating when entering a new UTC day.

Looks like this:
![Screen Shot 2020-11-26 at 2 58 51 PM](https://user-images.githubusercontent.com/10648471/100395954-f5ab3d80-2ff7-11eb-8aa0-d69b1c81724a.png)
