### PR TITLE
Show witnesses by default on PoC receipt map, and improve map auto focus / zoom

### DIFF
--- a/components/Txns/PocPath.js
+++ b/components/Txns/PocPath.js
@@ -11,7 +11,7 @@ const PocMapbox = dynamic(() => import('../PocMapbox'), {
 const initialState = {
   loading: true,
   loadingInitial: true,
-  showWitnesses: false,
+  showWitnesses: true,
 }
 
 class PocPath extends Component {


### PR DESCRIPTION
This PR has 2 changes:
1. Set the "Show witnesses" toggle to be on by default for PoC receipt pages
2. Make the map auto pan and zoom to include all hotspots in the view at the closest zoom possible, and centred on the X and Y axis (with padding around them)

Here's what that looks like:

# Before (new PoC challenge — beacon)
![Screen Shot 2020-12-16 at 11 16 51 AM](https://user-images.githubusercontent.com/10648471/102395664-4e834b80-3f90-11eb-8c63-06090ce1ee2a.png)

# After (new PoC challenge — beacon)
![Screen Shot 2020-12-16 at 11 17 13 AM](https://user-images.githubusercontent.com/10648471/102395681-56db8680-3f90-11eb-84d6-8952d385eefe.png)

-------
# Before (old PoC challenge — path)
![Screen Shot 2020-12-16 at 11 16 06 AM](https://user-images.githubusercontent.com/10648471/102395831-812d4400-3f90-11eb-90bf-db2ddbce06e7.png)

# After (old PoC challenge — path)
![Screen Shot 2020-12-16 at 11 15 05 AM](https://user-images.githubusercontent.com/10648471/102395890-9013f680-3f90-11eb-9dbd-2aa317e052c2.png)
