### PR TITLE
Fix witness distance display

### DIFF
--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -6,7 +6,7 @@ export const formatHotspotName = (dashedName) =>
 
 export const formatDistance = (meters) => {
   if (meters < 1000) {
-    return meters.toLocaleString() + ' m'
+    return meters.toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' m'
   }
 
   if (meters < 10000) {


### PR DESCRIPTION
This update fixes the distance display in 2 ways:
- the logic now matches how the backend check works (not checking for "too far")
- it now uses the correct resolution that gets returned in the `poc_v4_parent_res` chain variable, instead of a hardcoded resolution 12 check

We can improve on this again for #133  but for now this should fix #127