### PR TITLE
Show hotspot role in PoC Receipt in Activity List

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -227,6 +227,24 @@ const columns = (ownerAddress) => {
         )
       case 'rewards_v1':
         return <span>{txn.totalAmount.toString(2)}</span>
+      case 'poc_receipts_v1':
+        let detailText = ''
+        if (txn.challenger === ownerAddress) {
+          detailText = 'Challenger'
+        } else {
+          txn.path.map((p) => {
+            if (p.challengee === ownerAddress) {
+              return (detailText = 'Challengee')
+            } else {
+              p.witnesses.map((w) => {
+                if (w.gateway === ownerAddress) {
+                  return (detailText = 'Witness')
+                }
+              })
+            }
+          })
+        }
+        return <span>{detailText}</span>
       case 'transfer_hotspot_v1':
         if (txn.gateway === ownerAddress) {
           // it's on the hotspot page, don't show + or -
@@ -260,7 +278,7 @@ const columns = (ownerAddress) => {
       ),
     },
     {
-      title: 'Amount',
+      title: 'Details',
       dataIndex: 'amount',
       key: 'amount',
       render: (txt, txn) => (

--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -197,7 +197,7 @@ const rewardColumns = (hotspots, type) => {
 }
 
 const columns = (ownerAddress) => {
-  const activityAmount = (txn) => {
+  const activityDetails = (txn) => {
     switch (txn.type) {
       case 'state_channel_close_v1':
         let totalDcs = 0
@@ -231,14 +231,17 @@ const columns = (ownerAddress) => {
         let detailText = ''
         if (txn.challenger === ownerAddress) {
           detailText = 'Challenger'
+          return
         } else {
           txn.path.map((p) => {
             if (p.challengee === ownerAddress) {
-              return (detailText = 'Challengee')
+              detailText = 'Challengee'
+              return
             } else {
               p.witnesses.map((w) => {
                 if (w.gateway === ownerAddress) {
-                  return (detailText = 'Witness')
+                  detailText = 'Witness'
+                  return
                 }
               })
             }
@@ -265,25 +268,15 @@ const columns = (ownerAddress) => {
       title: 'Type',
       dataIndex: 'type',
       key: 'type',
-      render: (data) => <TxnTag type={data}></TxnTag>,
-    },
-    {
-      title: 'Hash',
-      dataIndex: 'hash',
-      key: 'hash',
-      render: (data) => (
-        <Link href={`/txns/${data}`}>
-          <a>{data.substring(0, 6)}...</a>
-        </Link>
-      ),
+      render: (data, txn) => <TxnTag type={data}></TxnTag>,
     },
     {
       title: 'Details',
-      dataIndex: 'amount',
-      key: 'amount',
+      dataIndex: 'details',
+      key: 'details',
       render: (txt, txn) => (
         <Link href={`/txns/${txn.hash}`}>
-          <a>{activityAmount(txn)}</a>
+          <a>{activityDetails(txn)}</a>
         </Link>
       ),
     },

--- a/components/Txns/PocReceiptsV1.js
+++ b/components/Txns/PocReceiptsV1.js
@@ -194,6 +194,8 @@ const PocReceiptsV1 = ({ txn, h3exclusionCells, h3maxHopCells }) => (
                               >
                                 <div className="poc-witness-table">
                                   {p.witnesses.map((w, i) => {
+                                    console.log(p)
+                                    console.log(w)
                                     const pDistance = p.challengeeLocation
                                       ? p.challengeeLocation
                                       : p.challengee_location

--- a/components/Txns/PocReceiptsV1.js
+++ b/components/Txns/PocReceiptsV1.js
@@ -194,8 +194,6 @@ const PocReceiptsV1 = ({ txn, h3exclusionCells, h3maxHopCells }) => (
                               >
                                 <div className="poc-witness-table">
                                   {p.witnesses.map((w, i) => {
-                                    console.log(p)
-                                    console.log(w)
                                     const pDistance = p.challengeeLocation
                                       ? p.challengeeLocation
                                       : p.challengee_location


### PR DESCRIPTION
Fixes #131 

Not sure if this is the best approach (happy to try something else if anyone disagrees), but I figured it would make sense to change the "Amount" column to "Details" and add this info there. That would also allow us to put non-amount details for other types of transaction (e.g. Assert Location could have the city name in that column):
![Screen Shot 2021-01-04 at 4 56 42 PM](https://user-images.githubusercontent.com/10648471/103594776-7d655100-4eae-11eb-9b64-54f304f6bbda.png)


Here's how it looks:
![Screen Shot 2021-01-04 at 4 57 52 PM](https://user-images.githubusercontent.com/10648471/103594692-468f3b00-4eae-11eb-8162-52c9b802f922.png)