### PR TITLE
Add earnings percent changes to hotspot page

### DIFF
--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -21,17 +21,36 @@ const RewardSummary = ({ rewards, rewardsLoading }) => {
       >
         <RewardSummaryCard
           timeframe="24 hours"
-          value={rewards.day?.toFixed(2).toLocaleString()}
+          value={rewards.day}
+          previousValue={rewards.lastDay}
+          percentChange={
+            rewards.day === 0 && rewards.lastDay === 0
+              ? // if both the period and the previous period rewards were 0, set percent change to 0
+                0
+              : ((rewards.day - rewards.lastDay) / rewards.lastDay) * 100
+          }
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="7 days"
-          value={rewards.week?.toFixed(2).toLocaleString()}
+          value={rewards.week}
+          previousValue={rewards.lastWeek}
+          percentChange={
+            rewards.week === 0 && rewards.lastWeek === 0
+              ? 0
+              : ((rewards.week - rewards.lastWeek) / rewards.lastWeek) * 100
+          }
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="30 days"
-          value={rewards.month?.toFixed(2).toLocaleString()}
+          value={rewards.month}
+          previousValue={rewards.lastMonth}
+          percentChange={
+            rewards.month === 0 && rewards.lastMonth === 0
+              ? 0
+              : ((rewards.month - rewards.lastMonth) / rewards.lastMonth) * 100
+          }
           rewardsLoading={rewardsLoading}
         />
       </div>

--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -22,34 +22,38 @@ const RewardSummary = ({ rewards, rewardsLoading }) => {
         <RewardSummaryCard
           timeframe="24 hours"
           value={rewards.day}
-          previousValue={rewards.lastDay}
+          previousValue={rewards.previousDay}
           percentChange={
-            rewards.day === 0 && rewards.lastDay === 0
+            rewards.day === 0 && rewards.previousDay === 0
               ? // if both the period and the previous period rewards were 0, set percent change to 0
                 0
-              : ((rewards.day - rewards.lastDay) / rewards.lastDay) * 100
+              : ((rewards.day - rewards.previousDay) / rewards.previousDay) *
+                100
           }
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="7 days"
           value={rewards.week}
-          previousValue={rewards.lastWeek}
+          previousValue={rewards.previousWeek}
           percentChange={
-            rewards.week === 0 && rewards.lastWeek === 0
+            rewards.week === 0 && rewards.previousWeek === 0
               ? 0
-              : ((rewards.week - rewards.lastWeek) / rewards.lastWeek) * 100
+              : ((rewards.week - rewards.previousWeek) / rewards.previousWeek) *
+                100
           }
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="30 days"
           value={rewards.month}
-          previousValue={rewards.lastMonth}
+          previousValue={rewards.previousMonth}
           percentChange={
-            rewards.month === 0 && rewards.lastMonth === 0
+            rewards.month === 0 && rewards.previousMonth === 0
               ? 0
-              : ((rewards.month - rewards.lastMonth) / rewards.lastMonth) * 100
+              : ((rewards.month - rewards.previousMonth) /
+                  rewards.previousMonth) *
+                100
           }
           rewardsLoading={rewardsLoading}
         />

--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -1,4 +1,5 @@
 import RewardSummaryCard from './RewardSummaryCard'
+import { calculatePercentChange } from './utils'
 
 const RewardSummary = ({ rewards, rewardsLoading }) => {
   return (
@@ -23,38 +24,30 @@ const RewardSummary = ({ rewards, rewardsLoading }) => {
           timeframe="24 hours"
           value={rewards.day}
           previousValue={rewards.previousDay}
-          percentChange={
-            rewards.day === 0 && rewards.previousDay === 0
-              ? // if both the period and the previous period rewards were 0, set percent change to 0
-                0
-              : ((rewards.day - rewards.previousDay) / rewards.previousDay) *
-                100
-          }
+          percentChange={calculatePercentChange(
+            rewards.day,
+            rewards.previousDay,
+          )}
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="7 days"
           value={rewards.week}
           previousValue={rewards.previousWeek}
-          percentChange={
-            rewards.week === 0 && rewards.previousWeek === 0
-              ? 0
-              : ((rewards.week - rewards.previousWeek) / rewards.previousWeek) *
-                100
-          }
+          percentChange={calculatePercentChange(
+            rewards.week,
+            rewards.previousWeek,
+          )}
           rewardsLoading={rewardsLoading}
         />
         <RewardSummaryCard
           timeframe="30 days"
           value={rewards.month}
           previousValue={rewards.previousMonth}
-          percentChange={
-            rewards.month === 0 && rewards.previousMonth === 0
-              ? 0
-              : ((rewards.month - rewards.previousMonth) /
-                  rewards.previousMonth) *
-                100
-          }
+          percentChange={calculatePercentChange(
+            rewards.month,
+            rewards.previousMonth,
+          )}
           rewardsLoading={rewardsLoading}
         />
       </div>

--- a/components/Hotspots/RewardSummaryCard.js
+++ b/components/Hotspots/RewardSummaryCard.js
@@ -60,7 +60,9 @@ const RewardSummaryCard = ({
             >
               {timeframe}
             </p>
-            <Tooltip title={`Previous ${timeframe}: ${previousValueString}`}>
+            <Tooltip
+              title={`Previous ${timeframe}: ${previousValueString} HNT`}
+            >
               <div
                 style={{
                   borderRadius: 5,

--- a/components/Hotspots/RewardSummaryCard.js
+++ b/components/Hotspots/RewardSummaryCard.js
@@ -1,6 +1,33 @@
-import { Skeleton } from 'antd'
+import { Tooltip, Skeleton } from 'antd'
 
-const RewardSummaryCard = ({ timeframe, value, rewardsLoading }) => {
+const RewardSummaryCard = ({
+  timeframe,
+  value,
+  previousValue,
+  rewardsLoading,
+  percentChange,
+}) => {
+  const valueString = value?.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+  const previousValueString = previousValue?.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+  const percentChangeString =
+    percentChange === 0
+      ? // if there wasn't a percentage change (both value and previousValue are 0), don't show the indicator
+        ''
+      : `${percentChange > 0 ? '+' : ''}${percentChange?.toLocaleString(
+          undefined,
+          {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          },
+        )}%`
+
   return (
     <div
       style={{
@@ -35,9 +62,32 @@ const RewardSummaryCard = ({ timeframe, value, rewardsLoading }) => {
                 fontSize: '32px',
               }}
             >
-              {value}
+              {valueString}
             </span>
             <span style={{ fontSize: '12px', marginLeft: '4px' }}>HNT</span>
+            <Tooltip title={`Previous ${timeframe}: ${previousValueString}`}>
+              <div
+                style={{
+                  borderRadius: 5,
+                  marginLeft: 10,
+                  padding: '5px 8px',
+                  display: 'inline',
+                  height: 'auto',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'soleil',
+                    color: percentChange >= 0 ? '#32C48D' : '#CA0926',
+                    fontWeight: 400,
+                    fontSize: '12px',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {percentChangeString}
+                </span>
+              </div>
+            </Tooltip>
           </div>
         </>
       )}

--- a/components/Hotspots/RewardSummaryCard.js
+++ b/components/Hotspots/RewardSummaryCard.js
@@ -1,4 +1,5 @@
 import { Tooltip, Skeleton } from 'antd'
+import { formatPercentChangeString } from './utils'
 
 const RewardSummaryCard = ({
   timeframe,
@@ -16,17 +17,7 @@ const RewardSummaryCard = ({
     maximumFractionDigits: 2,
   })
 
-  const percentChangeString =
-    percentChange === 0
-      ? // if there wasn't a percentage change (both value and previousValue are 0), don't show the indicator
-        ''
-      : `${percentChange > 0 ? '+' : ''}${percentChange?.toLocaleString(
-          undefined,
-          {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          },
-        )}%`
+  const percentChangeString = formatPercentChangeString(percentChange)
 
   return (
     <div
@@ -74,7 +65,7 @@ const RewardSummaryCard = ({
                 <span
                   style={{
                     fontFamily: 'soleil',
-                    color: percentChange >= 0 ? '#32C48D' : '#CA0926',
+                    color: percentChange > 0 ? '#32C48D' : '#CA0926',
                     fontWeight: 400,
                     fontSize: '12px',
                     whiteSpace: 'nowrap',

--- a/components/Hotspots/RewardSummaryCard.js
+++ b/components/Hotspots/RewardSummaryCard.js
@@ -43,34 +43,28 @@ const RewardSummaryCard = ({
         <Skeleton active paragraph={{ rows: 1 }} size="small" />
       ) : (
         <>
-          <p
+          <div
             style={{
-              margin: 0,
-              textTransform: 'uppercase',
-              fontSize: '12px',
-              color: '#6d6ea0',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
             }}
           >
-            {timeframe}
-          </p>
-          <div>
-            <span
+            <p
               style={{
-                fontFamily: 'soleil',
-                color: '#262625',
-                fontWeight: 400,
-                fontSize: '32px',
+                margin: 0,
+                textTransform: 'uppercase',
+                fontSize: '12px',
+                color: '#6d6ea0',
               }}
             >
-              {valueString}
-            </span>
-            <span style={{ fontSize: '12px', marginLeft: '4px' }}>HNT</span>
+              {timeframe}
+            </p>
             <Tooltip title={`Previous ${timeframe}: ${previousValueString}`}>
               <div
                 style={{
                   borderRadius: 5,
                   marginLeft: 10,
-                  padding: '5px 8px',
                   display: 'inline',
                   height: 'auto',
                 }}
@@ -88,6 +82,19 @@ const RewardSummaryCard = ({
                 </span>
               </div>
             </Tooltip>
+          </div>
+          <div>
+            <span
+              style={{
+                fontFamily: 'soleil',
+                color: '#262625',
+                fontWeight: 400,
+                fontSize: '32px',
+              }}
+            >
+              {valueString}
+            </span>
+            <span style={{ fontSize: '12px', marginLeft: '4px' }}>HNT</span>
           </div>
         </>
       )}

--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -39,3 +39,26 @@ export const formatLocation = (geocode0) => {
 
   return locationTerms.join(', ')
 }
+
+export const formatPercentChangeString = (percentChangeNumber) => {
+  const percentChangeString =
+    percentChangeNumber === 0
+      ? // if there wasn't a percentage change (both value and previousValue are 0), don't show the indicator
+        ``
+      : `${
+          percentChangeNumber > 0 ? '+' : ''
+        }${percentChangeNumber?.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}%`
+  return percentChangeString
+}
+
+export const calculatePercentChange = (value, previousValue) => {
+  const percentChangeValue =
+    value === 0 && previousValue === 0
+      ? // if both the period and the previous period rewards were 0, set percent change to 0
+        0
+      : ((value - previousValue) / previousValue) * 100
+  return percentChangeValue
+}

--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -56,8 +56,8 @@ export const formatPercentChangeString = (percentChangeNumber) => {
 
 export const calculatePercentChange = (value, previousValue) => {
   const percentChangeValue =
-    value === 0 && previousValue === 0
-      ? // if both the period and the previous period rewards were 0, set percent change to 0
+    (value === 0 && previousValue === 0) || previousValue === 0
+      ? // if both the period and the previous period rewards were 0, or the previous value is 0, set percent change to 0
         0
       : ((value - previousValue) / previousValue) * 100
   return percentChangeValue

--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -1,9 +1,14 @@
 import React from 'react'
-import { Table, Card } from 'antd'
+import { Table, Card, Tooltip } from 'antd'
 import round from 'lodash/round'
 import { Content } from './AppLayout'
 import Link from 'next/link'
-import { formatHotspotName, formatLocation } from './Hotspots/utils'
+import {
+  formatHotspotName,
+  formatLocation,
+  calculatePercentChange,
+  formatPercentChangeString,
+} from './Hotspots/utils'
 import { StatusCircle } from './Hotspots'
 
 const HotspotsList = ({ hotspots, loading }) => {
@@ -50,19 +55,75 @@ const hotspotColumns = [
     title: 'Rewards (24h)',
     dataIndex: 'rewards',
     key: 'rewardsDay',
-    render: (data) => round(data.day, 2),
+    render: (data) => {
+      const percentChange = calculatePercentChange(data.day, data.previousDay)
+      return (
+        <span>
+          {round(data.day, 2)}
+          <Tooltip title={`Previous day: ${round(data.previousDay, 2)} HNT`}>
+            <span
+              style={{
+                marginLeft: 5,
+                color: percentChange > 0 ? '#32C48D' : '#CA0926',
+              }}
+            >
+              {formatPercentChangeString(percentChange)}
+            </span>
+          </Tooltip>
+        </span>
+      )
+    },
   },
   {
     title: 'Rewards (7d)',
     dataIndex: 'rewards',
     key: 'rewardsWeek',
-    render: (data) => round(data.week, 2),
+    render: (data) => {
+      const percentChange = calculatePercentChange(data.week, data.previousWeek)
+      return (
+        <span>
+          {round(data.week, 2)}
+          <Tooltip title={`Previous week: ${round(data.previousWeek, 2)} HNT`}>
+            <span
+              style={{
+                marginLeft: 5,
+                color: percentChange > 0 ? '#32C48D' : '#CA0926',
+              }}
+            >
+              {formatPercentChangeString(percentChange)}
+            </span>
+          </Tooltip>
+        </span>
+      )
+    },
   },
   {
     title: 'Rewards (30d)',
     dataIndex: 'rewards',
     key: 'rewardsMonth',
-    render: (data) => round(data.month, 2),
+    render: (data) => {
+      const percentChange = calculatePercentChange(
+        data.month,
+        data.previousMonth,
+      )
+      return (
+        <span>
+          {round(data.month, 2)}
+          <Tooltip
+            title={`Previous month: ${round(data.previousMonth, 2)} HNT`}
+          >
+            <span
+              style={{
+                marginLeft: 5,
+                color: percentChange > 0 ? '#32C48D' : '#CA0926',
+              }}
+            >
+              {formatPercentChangeString(percentChange)}
+            </span>
+          </Tooltip>
+        </span>
+      )
+    },
   },
 ]
 

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -56,10 +56,10 @@ export const fetchRewardsSummary = async (address) => {
 
   return {
     day: sumBy(data.slice(0, 23), 'total'),
-    lastDay: sumBy(data.slice(23, 47), 'total'),
+    previousDay: sumBy(data.slice(23, 47), 'total'),
     week: sumBy(data.slice(0, 24 * 7 - 1), 'total'),
-    lastWeek: sumBy(data.slice(24 * 7 - 1, 24 * 7 * 2), 'total'),
+    previousWeek: sumBy(data.slice(24 * 7 - 1, 24 * 7 * 2), 'total'),
     month: sumBy(data.slice(0, 24 * 30 - 1), 'total'),
-    lastMonth: sumBy(data.slice(24 * 30 - 1, 24 * 30 * 2), 'total'),
+    previousMonth: sumBy(data.slice(24 * 30 - 1, 24 * 30 * 2), 'total'),
   }
 }

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -42,10 +42,11 @@ export const fetchRewardsSummary = async (address) => {
   // Use UTC version of current time so that the current day's rewards get included in the API response
 
   const monthAgo = sub(nowUTC, { days: 30 })
+  const twoMonthsAgo = sub(monthAgo, { days: 30 })
   const params = qs.stringify({
     // since the ISO format of the dates will always be a known length, substr(0, 19) will lop off the offset from the end
     // this should only have an effect locally in the dev environment, because doing new Date() on Heroku won't have an offset
-    min_time: formatISO(monthAgo).substr(0, 19),
+    min_time: formatISO(twoMonthsAgo).substr(0, 19),
     max_time: formatISO(nowUTC).substr(0, 19),
     bucket: 'hour',
   })
@@ -55,7 +56,10 @@ export const fetchRewardsSummary = async (address) => {
 
   return {
     day: sumBy(data.slice(0, 23), 'total'),
+    lastDay: sumBy(data.slice(23, 47), 'total'),
     week: sumBy(data.slice(0, 24 * 7 - 1), 'total'),
-    month: sumBy(data, 'total'),
+    lastWeek: sumBy(data.slice(24 * 7 - 1, 24 * 7 * 2), 'total'),
+    month: sumBy(data.slice(0, 24 * 30 - 1), 'total'),
+    lastMonth: sumBy(data.slice(24 * 30 - 1, 24 * 30 * 2), 'total'),
   }
 }


### PR DESCRIPTION
This is just a step toward better earnings visualization, but should help the Explorer at least get closer to feature parity with Sitebot and Mylar in the short term.

Here's what it looks like:
![Screen Shot 2021-01-14 at 12 13 39 PM](https://user-images.githubusercontent.com/10648471/104644099-2d327f80-5662-11eb-90c1-bbf2619914f7.png)

And I'm not sure about this UX choice, but for now I added the actual amount from the previous period to a tooltip that's accessible on hover over the change percent indicator.
![Screen Shot 2021-01-14 at 12 13 45 PM](https://user-images.githubusercontent.com/10648471/104644103-2dcb1600-5662-11eb-8e6b-d6b2774d7eb8.png)

And a few different scenarios (when the percent change === 0, or when it's negative):

Hotspot that recently went offline:
![Screen Shot 2021-01-14 at 12 16 29 PM](https://user-images.githubusercontent.com/10648471/104644477-a9c55e00-5662-11eb-8a28-c720b386c7a9.png)

Newly added hotspot:
![Screen Shot 2021-01-14 at 12 17 52 PM](https://user-images.githubusercontent.com/10648471/104644478-aa5df480-5662-11eb-99d6-86f07ff2fd03.png)
