### PR TITLE
Remove prefetching on pages with many <Link>s

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -184,7 +184,7 @@ const rewardColumns = (hotspots, type) => {
       render: (data) => (
         <span className="ant-table-cell-override">
           {data && (
-            <Link href={`/hotspots/${data}`}>
+            <Link href={`/hotspots/${data}`} prefetch={false}>
               <a>{animalHash(data)}</a>
             </Link>
           )}
@@ -266,7 +266,7 @@ const columns = (ownerAddress) => {
       dataIndex: 'type',
       key: 'type',
       render: (data, txn) => (
-        <Link href={`/txns/${txn.hash}`}>
+        <Link href={`/txns/${txn.hash}`} prefetch={false}>
           <a className="tag-link">
             <TxnTag type={data}></TxnTag>
           </a>
@@ -278,7 +278,7 @@ const columns = (ownerAddress) => {
       dataIndex: 'details',
       key: 'details',
       render: (txt, txn) => (
-        <Link href={`/txns/${txn.hash}`}>
+        <Link href={`/txns/${txn.hash}`} prefetch={false}>
           <a>{activityDetails(txn)}</a>
         </Link>
       ),
@@ -288,7 +288,7 @@ const columns = (ownerAddress) => {
       dataIndex: 'height',
       key: 'height',
       render: (height) => (
-        <Link href={`/blocks/${height}`}>
+        <Link href={`/blocks/${height}`} prefetch={false}>
           <a>{height}</a>
         </Link>
       ),

--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -32,7 +32,7 @@ const hotspotColumns = [
     render: (data, row) => (
       <>
         <StatusCircle status={row.status} />
-        <Link href={'/hotspots/' + row.address}>
+        <Link href={'/hotspots/' + row.address} prefetch={false}>
           <a style={{ fontFamily: 'soleil, sans-serif' }}>
             {formatHotspotName(data)}
           </a>

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -16,7 +16,7 @@ const columns = [
     render: (name, row) => (
       <>
         <StatusCircle status={row.status} />
-        <Link href={'/hotspots/' + row.address}>
+        <Link href={'/hotspots/' + row.address} prefetch={false}>
           <a style={{ fontFamily: 'soleil, sans-serif' }}>
             {formatHotspotName(name)}
           </a>

--- a/components/Txns/PocReceiptsV1.js
+++ b/components/Txns/PocReceiptsV1.js
@@ -63,7 +63,7 @@ const PocReceiptsV1 = ({ txn }) => {
           </Link>
         </Descriptions.Item>
         <Descriptions.Item label="Block Height" span={3}>
-          <Link href={'/blocks/' + txn.height}>
+          <Link href={'/blocks/' + txn.height} prefetch={false}>
             <a>{txn.height}</a>
           </Link>
         </Descriptions.Item>

--- a/components/Txns/RewardsV1.js
+++ b/components/Txns/RewardsV1.js
@@ -13,7 +13,7 @@ const columns = [
     render: (address) => (
       <div style={{ display: 'flex' }}>
         <AccountIcon address={address} style={{ marginRight: 4 }} />
-        <Link href={'/accounts/' + address}>
+        <Link href={'/accounts/' + address} prefetch={false}>
           <a>{address}</a>
         </Link>
       </div>

--- a/components/Txns/StateChannelCloseV1.js
+++ b/components/Txns/StateChannelCloseV1.js
@@ -23,7 +23,7 @@ class StateChannelCloseV1 extends Component {
         key: 'client',
         render: (data) => (
           <span>
-            <Link href={'/hotspots/' + data}>
+            <Link href={'/hotspots/' + data} prefetch={false}>
               <a>{animalHash(data)}</a>
             </Link>
           </span>

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -12,7 +12,7 @@ const columns = [
     render: (name, row) => (
       <>
         <StatusCircle status={row.status} />
-        <Link href={'/hotspots/' + row.address}>
+        <Link href={'/hotspots/' + row.address} prefetch={false}>
           <a style={{ fontFamily: 'soleil, sans-serif' }}>
             {formatHotspotName(name)}
           </a>

--- a/pages/accounts/richest.js
+++ b/pages/accounts/richest.js
@@ -23,7 +23,7 @@ function RichList({ accounts }) {
       dataIndex: 'address',
       key: 'address',
       render: (address) => (
-        <Link href={`/accounts/${address}`}>
+        <Link href={`/accounts/${address}`} prefetch={false}>
           <a style={{ fontWeight: '600' }}>{address}</a>
         </Link>
       ),

--- a/pages/blocks/[blockid].js
+++ b/pages/blocks/[blockid].js
@@ -47,7 +47,7 @@ const BlockView = ({ block, txns, height }) => {
       dataIndex: 'hash',
       key: 'hash',
       render: (hash) => (
-        <Link href={'/txns/' + hash}>
+        <Link href={'/txns/' + hash} prefetch={false}>
           <a>{hash}</a>
         </Link>
       ),


### PR DESCRIPTION
Remove prefetching from some pages with lots of <Link> tags to stop hammering the server with requests. Since Next prefetches all <Link> tags in the viewport, this is probably why the site went down with the latest update to move some of the data fetching into `getStaticProps` (txn pages, block pages)