### PR TITLE
Show invalid reason for invalid witnesses

### DIFF
--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -40,6 +40,26 @@ export const formatLocation = (geocode0) => {
   return locationTerms.join(', ')
 }
 
+export const formatWitnessInvalidReason = (rawInvalidReason) => {
+  switch (rawInvalidReason) {
+    case 'witness_too_close': {
+      return 'Witness too close'
+    }
+    case 'witness_rssi_too_high': {
+      return 'Witness RSSI too high'
+    }
+    case 'witness_on_incorrect_channel': {
+      return 'Witness on incorrect channel'
+    }
+    case 'witness_rssi_below_lower_bound': {
+      return 'Witness RSSI below lower bound'
+    }
+    default: {
+      return ''
+    }
+  }
+}
+
 export const formatPercentChangeString = (percentChangeNumber) => {
   const percentChangeString =
     percentChangeNumber === 0

--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -55,7 +55,7 @@ export const formatWitnessInvalidReason = (rawInvalidReason) => {
       return 'Witness RSSI below lower bound'
     }
     default: {
-      return ''
+      return `${rawInvalidReason}`
     }
   }
 }

--- a/components/Txns/PocInfoTable.js
+++ b/components/Txns/PocInfoTable.js
@@ -183,7 +183,7 @@ const PocInfoTable = ({
       rssi: (
         <span
           style={
-            !witness.isValid && witness.invalidReason.includes('rssi')
+            !witness.isValid && witness?.invalidReason?.includes('rssi')
               ? { color: '#CA0926' }
               : {}
           }
@@ -193,7 +193,7 @@ const PocInfoTable = ({
       distance: (
         <span
           style={
-            !witness.isValid && witness.invalidReason === 'witness_too_close'
+            !witness.isValid && witness?.invalidReason === 'witness_too_close'
               ? { color: '#CA0926' }
               : {}
           }
@@ -221,7 +221,6 @@ const PocInfoTable = ({
       style={witnessIndex !== 0 ? { paddingTop: 16 } : {}}
     >
       <span>
-        {/* <span>{witnessIndex + 1} — </span> */}
         <Link href={'/hotspots/' + witness.gateway}>
           <a className="poc-witness-name">{animalHash(witness.gateway)}</a>
         </Link>
@@ -233,9 +232,11 @@ const PocInfoTable = ({
         >
           {witness.is_valid || witness.isValid
             ? 'Valid witness'
-            : `Invalid witness — (${formatWitnessInvalidReason(
-                witness.invalidReason,
-              )})`}
+            : `Invalid witness${
+                witness.invalidReason !== undefined
+                  ? ` — (${formatWitnessInvalidReason(witness.invalidReason)})`
+                  : ''
+              }`}
         </span>
         <span className="poc-witness-info-table-container">
           <Table

--- a/components/Txns/PocInfoTable.js
+++ b/components/Txns/PocInfoTable.js
@@ -80,7 +80,6 @@ const PocInfoTable = ({
   witness,
   witnessIndex,
   participantIndex,
-  minValidH3Distance,
   pocH3CellResolution,
 }) => {
   let pLocation = participant.challengeeLocation

--- a/components/Txns/PocInfoTable.js
+++ b/components/Txns/PocInfoTable.js
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import animalHash from 'angry-purple-tiger'
 import { h3Distance, h3GetResolution, h3ToChildren, h3ToParent } from 'h3-js'
 import { Table, Tooltip } from 'antd'
-import { formatDistance } from '../Hotspots/utils'
+import { formatDistance, formatWitnessInvalidReason } from '../Hotspots/utils'
 
 // these values are from this table: https://h3geo.org/docs/core-library/restable
 const AVG_H3_HEX_EDGE_LENGTHS_IN_KM = [
@@ -110,8 +110,6 @@ const PocInfoTable = ({
 
   const witnessDistInKm = averageCellDiameter * witnessDistInH3Cells
 
-  const witnessDistanceIsValid = minValidH3Distance <= witnessDistInH3Cells
-
   const columns = []
 
   let columnCount = 2 // because RSSI and distance should always be there
@@ -183,12 +181,25 @@ const PocInfoTable = ({
   const data = [
     {
       key: '1',
-      rssi: `${witness?.signal}dBm`,
+      rssi: (
+        <span
+          style={
+            !witness.isValid && witness.invalidReason.includes('rssi')
+              ? { color: '#CA0926' }
+              : {}
+          }
+        >{`${witness.signal}dBm`}</span>
+      ),
       snr: `${witness.snr?.toFixed(2)}dB`,
       distance: (
-        <span style={!witnessDistanceIsValid ? { color: '#CA0926' } : {}}>
+        <span
+          style={
+            !witness.isValid && witness.invalidReason === 'witness_too_close'
+              ? { color: '#CA0926' }
+              : {}
+          }
+        >
           {formatDistance(witnessDistInKm * 1000)}
-          {!witnessDistanceIsValid && ' (too close)'}
         </span>
       ),
       datarate:
@@ -222,8 +233,10 @@ const PocInfoTable = ({
           }}
         >
           {witness.is_valid || witness.isValid
-            ? '(Valid witness)'
-            : '(Invalid witness)'}
+            ? 'Valid witness'
+            : `Invalid witness — (${formatWitnessInvalidReason(
+                witness.invalidReason,
+              )})`}
         </span>
         <span className="poc-witness-info-table-container">
           <Table

--- a/components/Txns/PocReceiptsV1.js
+++ b/components/Txns/PocReceiptsV1.js
@@ -37,15 +37,9 @@ const formatPocRadioInfo = (receipt) => {
 }
 
 const PocReceiptsV1 = ({ txn }) => {
-  const [minValidH3Distance, setMinValidH3Distance] = useState()
-  const [pocH3CellResolution, setPocH3CellResolution] = useState()
+  const [pocH3CellResolution, setPocH3CellResolution] = useState(11)
 
   useEffect(async () => {
-    await fetch('https://api.helium.io/v1/vars/poc_v4_exclusion_cells')
-      .then((res) => res.json())
-      .then((min) => {
-        setMinValidH3Distance(min.data)
-      })
     await fetch('https://api.helium.io/v1/vars/poc_v4_parent_res')
       .then((res) => res.json())
       .then((resolution) => {
@@ -199,9 +193,6 @@ const PocReceiptsV1 = ({ txn }) => {
                                           witness={w}
                                           witnessIndex={i}
                                           participantIndex={participantIndex}
-                                          minValidH3Distance={
-                                            minValidH3Distance
-                                          }
                                           pocH3CellResolution={
                                             pocH3CellResolution
                                           }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@helium/crypto": "^3.1.0",
     "@helium/currency": "^3.0.0",
-    "@helium/http": "^3.14.0",
+    "@helium/http": "^3.18.0",
     "@mapbox/mapbox-sdk": "^0.11.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@helium/crypto": "^3.1.0",
     "@helium/currency": "^3.0.0",
-    "@helium/http": "^3.12.0",
+    "@helium/http": "^3.14.0",
     "@mapbox/mapbox-sdk": "^0.11.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,13 +1449,13 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.12.0.tgz#7de32ca97a8083bee06fe1a9df686b0f39954caf"
-  integrity sha512-Gm9NCLgDu23e5pCLdjYbJr+a/XjKxMJIeGAyO9Tz0gAGRynxAyJ6UpkX2iLQ3vBojRJYUOYdqk8LEjy3KLZMXw==
+"@helium/http@^3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.14.0.tgz#a1a15b89b566b162eae41655364785267f2b8fab"
+  integrity sha512-DPO+5apS+BBWI0TLOTIFsoX5hZnU7DGDJgJ9IfwfONW7pgSDrtxa9s87RccoTsVdwnEXn/rRkZRMd4RlbHr0FA==
   dependencies:
     "@helium/currency" "^3.0.0"
-    axios "^0.21.0"
+    axios "^0.21.1"
     camelcase-keys "^6.2.2"
     qs "^6.9.3"
     retry-axios "^2.1.2"
@@ -3048,10 +3048,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
-  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -10892,7 +10892,12 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.3, qs@^6.9.4:
+qs@^6.9.3:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
+qs@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,12 +1449,19 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.14.0.tgz#a1a15b89b566b162eae41655364785267f2b8fab"
-  integrity sha512-DPO+5apS+BBWI0TLOTIFsoX5hZnU7DGDJgJ9IfwfONW7pgSDrtxa9s87RccoTsVdwnEXn/rRkZRMd4RlbHr0FA==
+"@helium/currency@^3.16.0":
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/@helium/currency/-/currency-3.16.0.tgz#013fd909398092831ccba92b10311e3127a53b7e"
+  integrity sha512-NT4ErsH22iR4ERKCvnxXeZaOWsDV0AtvNKn7qLAeCez3TWlzy6U/ojiKHhi95875uPUotc/Ancz8yXuCt6NPaQ==
   dependencies:
-    "@helium/currency" "^3.0.0"
+    bignumber.js "^9.0.0"
+
+"@helium/http@^3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.18.0.tgz#2f297e80cfecc73a8781bf19f2c46dca74714f06"
+  integrity sha512-X051WeCYxhup2rRKU4YenwLSLrCtMwQwPpV8eO2vMKMALnJ10PWe3c+rixpqwrWukyJ8kbJwaG5Xf2XoitaSOA==
+  dependencies:
+    "@helium/currency" "^3.16.0"
     axios "^0.21.1"
     camelcase-keys "^6.2.2"
     qs "^6.9.3"


### PR DESCRIPTION
Added the newly exposed invalid reasons for invalid witnesses in a PoC receipt transaction. Here's what they look like:

![Screen Shot 2021-01-19 at 3 55 04 PM](https://user-images.githubusercontent.com/10648471/105113249-66f7f180-5a79-11eb-9aea-c1525209a916.png)
![Screen Shot 2021-01-19 at 3 56 07 PM](https://user-images.githubusercontent.com/10648471/105113251-68291e80-5a79-11eb-9c04-9ec4a480cb67.png)
![Screen Shot 2021-01-19 at 3 56 14 PM](https://user-images.githubusercontent.com/10648471/105113252-68291e80-5a79-11eb-9daf-ba5396128306.png)
![Screen Shot 2021-01-19 at 3 56 43 PM](https://user-images.githubusercontent.com/10648471/105113255-68c1b500-5a79-11eb-98f8-6e76fefcdd09.png)
![Screen Shot 2021-01-19 at 3 56 55 PM](https://user-images.githubusercontent.com/10648471/105113256-68c1b500-5a79-11eb-98b0-8b52c0653e13.png)
