### PR TITLE
Mapbox enhancements

### DIFF
--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { Tooltip } from 'antd'
+import animalHash from 'angry-purple-tiger'
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
 import { withRouter } from 'next/router'
 
@@ -76,13 +78,15 @@ const HotspotMapbox = ({
     >
       {showNearbyHotspots &&
         nearbyHotspots.map((h) => (
-          <Marker
-            key={`nearby-${h.address}`}
-            style={styles.nearbyMarker}
-            anchor="center"
-            coordinates={[h.lng, h.lat]}
-            onClick={() => router.push(`/hotspots/${h.address}`)}
-          />
+          <Tooltip title={animalHash(h.address)}>
+            <Marker
+              key={`nearby-${h.address}`}
+              style={styles.nearbyMarker}
+              anchor="center"
+              coordinates={[h.lng, h.lat]}
+              onClick={() => router.push(`/hotspots/${h.address}`)}
+            />
+          </Tooltip>
         ))}
 
       <Marker
@@ -98,13 +102,15 @@ const HotspotMapbox = ({
       {showWitnesses &&
         witnesses.map((w) => (
           <>
-            <Marker
-              key={w.address}
-              style={styles.witnessMarker}
-              anchor="center"
-              coordinates={[w.lng, w.lat]}
-              onClick={() => router.push(`/hotspots/${w.address}`)}
-            ></Marker>
+            <Tooltip title={animalHash(w.address)}>
+              <Marker
+                key={w.address}
+                style={styles.witnessMarker}
+                anchor="center"
+                coordinates={[w.lng, w.lat]}
+                onClick={() => router.push(`/hotspots/${w.address}`)}
+              ></Marker>
+            </Tooltip>
             <Layer
               key={'line-' + w.address}
               type="line"

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Tooltip } from 'antd'
-import Link from 'next/link'
 import { findBounds } from '../Txns/utils'
 import animalHash from 'angry-purple-tiger'
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
@@ -109,18 +108,15 @@ const HotspotMapbox = ({
       >
         {showNearbyHotspots &&
           nearbyHotspots.map((h) => (
-            <Link href={`/hotspots/${h.address}`} prefetch={false}>
-              <a>
-                <Tooltip title={animalHash(h.address)}>
-                  <Marker
-                    key={`nearby-${h.address}`}
-                    style={styles.nearbyMarker}
-                    anchor="center"
-                    coordinates={[h.lng, h.lat]}
-                  />
-                </Tooltip>
-              </a>
-            </Link>
+            <Tooltip title={animalHash(h.address)}>
+              <Marker
+                key={`nearby-${h.address}`}
+                style={styles.nearbyMarker}
+                anchor="center"
+                coordinates={[h.lng, h.lat]}
+                onClick={() => router.push(`/hotspots/${h.address}`)}
+              />
+            </Tooltip>
           ))}
 
         <Marker

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import { Tooltip } from 'antd'
+import Link from 'next/link'
+import { findBounds } from '../Txns/utils'
 import animalHash from 'angry-purple-tiger'
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
 import { withRouter } from 'next/router'
@@ -95,78 +97,78 @@ const HotspotMapbox = ({
   }
 
   if (hotspot.lng !== undefined && hotspot.lat !== undefined) {
-  return (
-    <Mapbox
-      style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
-      container="map"
-      containerStyle={{
-        width: '100%',
-      }}
-      movingMethod="jumpTo"
+    return (
+      <Mapbox
+        style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
+        container="map"
+        containerStyle={{
+          width: '100%',
+        }}
+        movingMethod="jumpTo"
         {...mapProps}
-    >
-      {showNearbyHotspots &&
-        nearbyHotspots.map((h) => (
+      >
+        {showNearbyHotspots &&
+          nearbyHotspots.map((h) => (
             <Link href={`/hotspots/${h.address}`} prefetch={false}>
               <a>
-          <Tooltip title={animalHash(h.address)}>
-            <Marker
-              key={`nearby-${h.address}`}
-              style={styles.nearbyMarker}
-              anchor="center"
-              coordinates={[h.lng, h.lat]}
-            />
-          </Tooltip>
+                <Tooltip title={animalHash(h.address)}>
+                  <Marker
+                    key={`nearby-${h.address}`}
+                    style={styles.nearbyMarker}
+                    anchor="center"
+                    coordinates={[h.lng, h.lat]}
+                  />
+                </Tooltip>
               </a>
             </Link>
-        ))}
+          ))}
 
-      <Marker
-        key={hotspot.address}
-        style={styles.gatewayMarker}
-        anchor="center"
-        coordinates={[
-          hotspot.lng ? hotspot.lng : 0,
-          hotspot.lat ? hotspot.lat : 0,
-        ]}
-      />
+        <Marker
+          key={hotspot.address}
+          style={styles.gatewayMarker}
+          anchor="center"
+          coordinates={[
+            hotspot.lng ? hotspot.lng : 0,
+            hotspot.lat ? hotspot.lat : 0,
+          ]}
+        />
 
-      {showWitnesses &&
-        witnesses.map((w) => (
-          <>
-            <Tooltip title={animalHash(w.address)}>
-              <Marker
-                key={w.address}
-                style={styles.witnessMarker}
-                anchor="center"
-                coordinates={[w.lng, w.lat]}
-                onClick={() => router.push(`/hotspots/${w.address}`)}
-              ></Marker>
-            </Tooltip>
-            <Layer
-              key={'line-' + w.address}
-              type="line"
-              layout={{
-                'line-cap': 'round',
-                'line-join': 'round',
-              }}
-              paint={{
-                'line-color': '#F1C40F',
-                'line-width': 2,
-                'line-opacity': 0.3,
-              }}
-            >
-              <Feature
-                coordinates={[
-                  [w.lng, w.lat],
-                  [hotspot.lng, hotspot.lat],
-                ]}
-              />
-            </Layer>
-          </>
-        ))}
-    </Mapbox>
-  )
+        {showWitnesses &&
+          witnesses.map((w) => (
+            <>
+              <Tooltip title={animalHash(w.address)}>
+                <Marker
+                  key={w.address}
+                  style={styles.witnessMarker}
+                  anchor="center"
+                  coordinates={[w.lng, w.lat]}
+                  onClick={() => router.push(`/hotspots/${w.address}`)}
+                ></Marker>
+              </Tooltip>
+              <Layer
+                key={'line-' + w.address}
+                type="line"
+                layout={{
+                  'line-cap': 'round',
+                  'line-join': 'round',
+                }}
+                paint={{
+                  'line-color': '#F1C40F',
+                  'line-width': 2,
+                  'line-opacity': 0.3,
+                }}
+              >
+                <Feature
+                  coordinates={[
+                    [w.lng, w.lat],
+                    [hotspot.lng, hotspot.lat],
+                  ]}
+                />
+              </Layer>
+            </>
+          ))}
+      </Mapbox>
+    )
   } else {
     return (
       <div

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -65,16 +65,45 @@ const HotspotMapbox = ({
   showNearbyHotspots,
   router,
 }) => {
+  const boundsLocations = []
+  // include hotspot in centering / zooming logic
+  boundsLocations.push({ lng: hotspot?.lng, lat: hotspot?.lat })
+
+  // include witnesses in centering / zooming logic
+  witnesses.map((w) => boundsLocations.push({ lng: w?.lng, lat: w?.lat }))
+
+  // include nearby hotspots in centering / zooming logic
+  nearbyHotspots.map((h) =>
+    boundsLocations.push({ lng: h?._geoloc.lng, lat: h?._geoloc.lat }),
+  )
+
+  // calculate map bounds
+  const mapBounds = findBounds(boundsLocations)
+
+  const mapProps = {}
+
+  if (boundsLocations.length === 1) {
+    // if the hotspot doesn't have any witnesses or nearby hotspots, centre on the hotspot by itself, at a decent zoom level
+    mapProps.zoom = [12]
+    mapProps.center = [
+      hotspot?.lng ? hotspot.lng : 0,
+      hotspot?.lat ? hotspot.lat : 0,
+    ]
+  } else {
+    mapProps.fitBounds = mapBounds
+    mapProps.fitBoundsOptions = { padding: 100, animate: false }
+  }
+
+  if (hotspot.lng !== undefined && hotspot.lat !== undefined) {
   return (
     <Mapbox
       style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
       container="map"
-      center={[hotspot.lng ? hotspot.lng : 0, hotspot.lat ? hotspot.lat : 0]}
       containerStyle={{
         width: '100%',
       }}
-      zoom={[11]}
       movingMethod="jumpTo"
+        {...mapProps}
     >
       {showNearbyHotspots &&
         nearbyHotspots.map((h) => (
@@ -135,5 +164,37 @@ const HotspotMapbox = ({
         ))}
     </Mapbox>
   )
+  } else {
+    return (
+      <div
+        className="no-location-set"
+        style={{
+          backgroundColor: '#324b61',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: 18,
+            height: 18,
+            borderRadius: '50%',
+            backgroundColor: '#A984FF',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            border: '3px solid #8B62EA',
+            boxShadow: '0px 2px 4px 0px rgba(0,0,0,0.5)',
+            marginBottom: 14,
+          }}
+        />
+        <p style={{ fontFamily: 'soleil', fontSize: '18px', color: 'white' }}>
+          No location set
+        </p>
+      </div>
+    )
+  }
 }
 export default withRouter(HotspotMapbox)

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -107,15 +107,18 @@ const HotspotMapbox = ({
     >
       {showNearbyHotspots &&
         nearbyHotspots.map((h) => (
+            <Link href={`/hotspots/${h.address}`} prefetch={false}>
+              <a>
           <Tooltip title={animalHash(h.address)}>
             <Marker
               key={`nearby-${h.address}`}
               style={styles.nearbyMarker}
               anchor="center"
               coordinates={[h.lng, h.lat]}
-              onClick={() => router.push(`/hotspots/${h.address}`)}
             />
           </Tooltip>
+              </a>
+            </Link>
         ))}
 
       <Marker

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -74,9 +74,9 @@ const HotspotMapbox = ({
   witnesses.map((w) => boundsLocations.push({ lng: w?.lng, lat: w?.lat }))
 
   // include nearby hotspots in centering / zooming logic
-  nearbyHotspots.map((h) =>
-    boundsLocations.push({ lng: h?._geoloc.lng, lat: h?._geoloc.lat }),
-  )
+  nearbyHotspots.map((h) => {
+    boundsLocations.push({ lng: h?._geoloc.lng, lat: h?._geoloc.lat })
+  })
 
   // calculate map bounds
   const mapBounds = findBounds(boundsLocations)
@@ -92,7 +92,7 @@ const HotspotMapbox = ({
     ]
   } else {
     mapProps.fitBounds = mapBounds
-    mapProps.fitBoundsOptions = { padding: 100, animate: false }
+    mapProps.fitBoundsOptions = { padding: 25, animate: false }
   }
 
   if (hotspot.lng !== undefined && hotspot.lat !== undefined) {

--- a/components/Txns/ConsensusMapbox.js
+++ b/components/Txns/ConsensusMapbox.js
@@ -1,6 +1,5 @@
 import ReactMapboxGl, { Marker } from 'react-mapbox-gl'
 import { findBounds } from './utils'
-import Link from 'next/link'
 import animalHash from 'angry-purple-tiger'
 import { Tooltip } from 'antd'
 
@@ -45,22 +44,19 @@ const ConsensusMapbox = ({ members }) => {
     >
       {members?.map((m, idx) => {
         return (
-          <Link href={`/hotspots/${m.address}`} prefetch={false}>
-            <a>
-              <Tooltip title={animalHash(m.address)}>
-                <Marker
-                  key={m.address}
-                  style={styles.consensusMember}
-                  anchor="center"
-                  coordinates={[m?.lng, m?.lat]}
-                >
-                  <span style={{ color: 'white', fontSize: '10px' }}>
-                    {idx + 1}
-                  </span>
-                </Marker>
-              </Tooltip>
-            </a>
-          </Link>
+          <Tooltip title={animalHash(m.address)}>
+            <Marker
+              key={m.address}
+              style={styles.consensusMember}
+              anchor="center"
+              coordinates={[m?.lng, m?.lat]}
+              onClick={() => router.push(`/hotspots/${m.address}`)}
+            >
+              <span style={{ color: 'white', fontSize: '10px' }}>
+                {idx + 1}
+              </span>
+            </Marker>
+          </Tooltip>
         )
       })}
     </Mapbox>

--- a/components/Txns/ConsensusMapbox.js
+++ b/components/Txns/ConsensusMapbox.js
@@ -1,5 +1,8 @@
 import ReactMapboxGl, { Marker } from 'react-mapbox-gl'
 import { findBounds } from './utils'
+import Link from 'next/link'
+import animalHash from 'angry-purple-tiger'
+import { Tooltip } from 'antd'
 
 const Mapbox = ReactMapboxGl({
   accessToken: process.env.NEXT_PUBLIC_MAPBOX_KEY,
@@ -42,14 +45,22 @@ const ConsensusMapbox = ({ members }) => {
     >
       {members?.map((m, idx) => {
         return (
-          <Marker
-            key={m.address}
-            style={styles.consensusMember}
-            anchor="center"
-            coordinates={[m?.lng, m?.lat]}
-          >
-            <span style={{ color: 'white', fontSize: '10px' }}>{idx + 1}</span>
-          </Marker>
+          <Link href={`/hotspots/${m.address}`} prefetch={false}>
+            <a>
+              <Tooltip title={animalHash(m.address)}>
+                <Marker
+                  key={m.address}
+                  style={styles.consensusMember}
+                  anchor="center"
+                  coordinates={[m?.lng, m?.lat]}
+                >
+                  <span style={{ color: 'white', fontSize: '10px' }}>
+                    {idx + 1}
+                  </span>
+                </Marker>
+              </Tooltip>
+            </a>
+          </Link>
         )
       })}
     </Mapbox>

--- a/components/Txns/PocMapbox.js
+++ b/components/Txns/PocMapbox.js
@@ -1,5 +1,8 @@
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
 import { h3ToGeo } from 'h3-js'
+import { Tooltip } from 'antd'
+import Link from 'next/link'
+import animalHash from 'angry-purple-tiger'
 import { findBounds } from './utils'
 
 const Mapbox = ReactMapboxGl({
@@ -123,32 +126,41 @@ const PocMapbox = ({ path, showWitnesses }) => {
       {path.map((p, idx) => {
         return (
           <span key={`${p}-${idx}`}>
-            <Marker
-              key={p.challengee}
-              style={
-                p.receipt ||
-                p.witnesses.length > 0 ||
-                (path[idx + 1] &&
-                  (path[idx + 1].receipt || path[idx + 1].witnesses.length > 0))
-                  ? styles.gatewaySuccess
-                  : styles.gatewayFailed
-              }
-              anchor="center"
-              coordinates={[
-                p.challengee_lon
-                  ? p.challengee_lon
-                  : p.challengeeLon
-                  ? p.challengeeLon
-                  : 0,
-                p.challengee_lat
-                  ? p.challengee_lat
-                  : p.challengeeLat
-                  ? p.challengeeLat
-                  : 0,
-              ]}
-            >
-              <span style={{ color: 'white', fontSize: '8px' }}>{idx + 1}</span>
-            </Marker>
+            <Link href={`/hotspots/${p.challengee}`} prefetch={false}>
+              <a>
+                <Tooltip title={animalHash(p.challengee)}>
+                  <Marker
+                    key={p.challengee}
+                    style={
+                      p.receipt ||
+                      p.witnesses.length > 0 ||
+                      (path[idx + 1] &&
+                        (path[idx + 1].receipt ||
+                          path[idx + 1].witnesses.length > 0))
+                        ? styles.gatewaySuccess
+                        : styles.gatewayFailed
+                    }
+                    anchor="center"
+                    coordinates={[
+                      p.challengee_lon
+                        ? p.challengee_lon
+                        : p.challengeeLon
+                        ? p.challengeeLon
+                        : 0,
+                      p.challengee_lat
+                        ? p.challengee_lat
+                        : p.challengeeLat
+                        ? p.challengeeLat
+                        : 0,
+                    ]}
+                  >
+                    <span style={{ color: 'white', fontSize: '8px' }}>
+                      {idx + 1}
+                    </span>
+                  </Marker>
+                </Tooltip>
+              </a>
+            </Link>
             <Layer
               key={'line-' + p.challengee}
               type="line"
@@ -198,19 +210,25 @@ const PocMapbox = ({ path, showWitnesses }) => {
               p.witnesses.map((w) => {
                 return (
                   <span>
-                    <Marker
-                      key={w.address}
-                      style={
-                        w.is_valid || w.isValid
-                          ? styles.witnessMarkerValid
-                          : styles.witnessMarkerInvalid
-                      }
-                      anchor="center"
-                      coordinates={[
-                        h3ToGeo(w.location)[1],
-                        h3ToGeo(w.location)[0],
-                      ]}
-                    ></Marker>
+                    <Link href={`/hotspots/${w.gateway}`} prefetch={false}>
+                      <a>
+                        <Tooltip title={animalHash(w.gateway)}>
+                          <Marker
+                            key={w.gateway}
+                            style={
+                              w.is_valid || w.isValid
+                                ? styles.witnessMarkerValid
+                                : styles.witnessMarkerInvalid
+                            }
+                            anchor="center"
+                            coordinates={[
+                              h3ToGeo(w.location)[1],
+                              h3ToGeo(w.location)[0],
+                            ]}
+                          ></Marker>
+                        </Tooltip>
+                      </a>
+                    </Link>
                     <Layer
                       key={'line-' + w.address}
                       type="line"

--- a/components/Txns/PocMapbox.js
+++ b/components/Txns/PocMapbox.js
@@ -1,7 +1,6 @@
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
 import { h3ToGeo } from 'h3-js'
 import { Tooltip } from 'antd'
-import Link from 'next/link'
 import animalHash from 'angry-purple-tiger'
 import { findBounds } from './utils'
 
@@ -82,191 +81,168 @@ const styles = {
 
 const PocMapbox = ({ path, showWitnesses }) => {
   const locations = []
-  if (path.length === 1) {
-    // after beaconing challenges
-    path[0].witnesses.map((w) =>
-      locations.push({
-        lng: h3ToGeo(w.location)[1],
-        lat: h3ToGeo(w.location)[0],
-      }),
-    )
-    locations.push({ lng: path[0].challengeeLon, lat: path[0].challengeeLat })
-  } else {
-    // before beaconing challenges
-    path.map((p) => {
-      // include all hotspots involved in the challenge
-      locations.push({ lng: p?.challengeeLon, lat: p?.challengeeLat })
-      // if witnesses are included, include them in finding the bounds
-      if (showWitnesses)
-        p.witnesses.map((w) =>
-          locations.push({
-            lng: h3ToGeo(w.location)[1],
-            lat: h3ToGeo(w.location)[0],
-          }),
-        )
-    })
+
+  const pathHasLocations =
+    path.length > 0 && path[0].challengeeLon && path[0].challengeeLat
+
+  if (pathHasLocations) {
+    if (path.length === 1) {
+      // after beaconing challenges
+      path[0].witnesses.map((w) =>
+        locations.push({
+          lng: h3ToGeo(w.location)[1],
+          lat: h3ToGeo(w.location)[0],
+        }),
+      )
+      locations.push({ lng: path[0].challengeeLon, lat: path[0].challengeeLat })
+    } else {
+      // before beaconing challenges
+      path.map((p) => {
+        // include all hotspots involved in the challenge
+        locations.push({ lng: p?.challengeeLon, lat: p?.challengeeLat })
+        // if witnesses are included, include them in finding the bounds
+        if (showWitnesses)
+          p.witnesses.map((w) =>
+            locations.push({
+              lng: h3ToGeo(w.location)[1],
+              lat: h3ToGeo(w.location)[0],
+            }),
+          )
+      })
+    }
   }
+
   const mapBounds = findBounds(locations)
 
-  return (
-    <Mapbox
-      style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
-      container="map"
-      fitBounds={mapBounds}
-      fitBoundsOptions={{
-        padding: 100,
-        animate: false,
-      }}
-      containerStyle={{
-        height: '600px',
-        width: '100%',
-      }}
-      movingMethod="jumpTo"
-    >
-      {path.map((p, idx) => {
-        return (
-          <span key={`${p}-${idx}`}>
-            <Link href={`/hotspots/${p.challengee}`} prefetch={false}>
-              <a>
-                <Tooltip title={animalHash(p.challengee)}>
-                  <Marker
-                    key={p.challengee}
-                    style={
-                      p.receipt ||
-                      p.witnesses.length > 0 ||
-                      (path[idx + 1] &&
-                        (path[idx + 1].receipt ||
-                          path[idx + 1].witnesses.length > 0))
-                        ? styles.gatewaySuccess
-                        : styles.gatewayFailed
-                    }
-                    anchor="center"
-                    coordinates={[
-                      p.challengee_lon
-                        ? p.challengee_lon
-                        : p.challengeeLon
-                        ? p.challengeeLon
-                        : 0,
-                      p.challengee_lat
-                        ? p.challengee_lat
-                        : p.challengeeLat
-                        ? p.challengeeLat
-                        : 0,
-                    ]}
-                  >
-                    <span style={{ color: 'white', fontSize: '8px' }}>
-                      {idx + 1}
-                    </span>
-                  </Marker>
-                </Tooltip>
-              </a>
-            </Link>
-            <Layer
-              key={'line-' + p.challengee}
-              type="line"
-              layout={{ 'line-cap': 'round', 'line-join': 'round' }}
-              paint={
-                p.receipt ||
-                p.witnesses.length > 0 ||
-                (path[idx + 1] &&
-                  (path[idx + 1].receipt || path[idx + 1].witnesses.length > 0))
-                  ? styles.lineSuccess
-                  : styles.lineFailure
-              }
-            >
-              <Feature
-                coordinates={[
-                  [
-                    p.challengee_lon
-                      ? p.challengee_lon
-                      : p.challengeeLon
-                      ? p.challengeeLon
-                      : 0,
-                    p.challengee_lat
-                      ? p.challengee_lat
-                      : p.challengeeLat
-                      ? p.challengeeLat
-                      : 0,
-                  ],
-                  path[idx + 1]
-                    ? [
-                        path[idx + 1].challengee_lon
-                          ? path[idx + 1].challengee_lon
-                          : path[idx + 1].challengeeLon
-                          ? path[idx + 1].challengeeLon
-                          : 0,
-                        path[idx + 1].challengee_lat
-                          ? path[idx + 1].challengee_lat
-                          : path[idx + 1].challengeeLat
-                          ? path[idx + 1].challengeeLat
-                          : 0,
-                      ]
-                    : [false],
-                ]}
-              />
-            </Layer>
-            {p.witnesses.length > 0 &&
-              showWitnesses &&
-              p.witnesses.map((w) => {
-                return (
-                  <span>
-                    <Link href={`/hotspots/${w.gateway}`} prefetch={false}>
-                      <a>
-                        <Tooltip title={animalHash(w.gateway)}>
-                          <Marker
-                            key={w.gateway}
-                            style={
-                              w.is_valid || w.isValid
-                                ? styles.witnessMarkerValid
-                                : styles.witnessMarkerInvalid
-                            }
-                            anchor="center"
-                            coordinates={[
-                              h3ToGeo(w.location)[1],
-                              h3ToGeo(w.location)[0],
-                            ]}
-                          ></Marker>
-                        </Tooltip>
-                      </a>
-                    </Link>
-                    <Layer
-                      key={'line-' + w.address}
-                      type="line"
-                      layout={{
-                        'line-cap': 'round',
-                        'line-join': 'round',
-                      }}
-                      paint={
-                        w.is_valid || w.isValid
-                          ? styles.witnessLineValid
-                          : styles.witnessLineInvalid
-                      }
-                    >
-                      <Feature
-                        coordinates={[
-                          [h3ToGeo(w.location)[1], h3ToGeo(w.location)[0]],
-                          [
-                            p.challengee_lon
-                              ? p.challengee_lon
-                              : p.challengeeLon
-                              ? p.challengeeLon
-                              : 0,
-                            p.challengee_lat
-                              ? p.challengee_lat
-                              : p.challengeeLat
-                              ? p.challengeeLat
-                              : 0,
-                          ],
-                        ]}
-                      />
-                    </Layer>
+  if (pathHasLocations) {
+    return (
+      <Mapbox
+        style={`mapbox://styles/petermain/cjyzlw0av4grj1ck97d8r0yrk`}
+        container="map"
+        fitBounds={mapBounds}
+        fitBoundsOptions={{
+          padding: 100,
+          animate: false,
+        }}
+        containerStyle={{
+          height: '600px',
+          width: '100%',
+        }}
+        movingMethod="jumpTo"
+      >
+        {path.map((p, idx) => {
+          return (
+            <span key={`${p}-${idx}`}>
+              <Tooltip title={animalHash(p.challengee)}>
+                <Marker
+                  key={p.challengee}
+                  style={
+                    p.receipt ||
+                    p.witnesses.length > 0 ||
+                    (path[idx + 1] &&
+                      (path[idx + 1].receipt ||
+                        path[idx + 1].witnesses.length > 0))
+                      ? styles.gatewaySuccess
+                      : styles.gatewayFailed
+                  }
+                  anchor="center"
+                  coordinates={[
+                    p.challengeeLon ? p.challengeeLon : 0,
+                    p.challengeeLat ? p.challengeeLat : 0,
+                  ]}
+                  onClick={() => router.push(`/hotspots/${p.challengee}`)}
+                >
+                  <span style={{ color: 'white', fontSize: '8px' }}>
+                    {idx + 1}
                   </span>
-                )
-              })}
-          </span>
-        )
-      })}
-    </Mapbox>
-  )
+                </Marker>
+              </Tooltip>
+              <Layer
+                key={'line-' + p.challengee}
+                type="line"
+                layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+                paint={
+                  p.receipt ||
+                  p.witnesses.length > 0 ||
+                  (path[idx + 1] &&
+                    (path[idx + 1].receipt ||
+                      path[idx + 1].witnesses.length > 0))
+                    ? styles.lineSuccess
+                    : styles.lineFailure
+                }
+              >
+                <Feature
+                  coordinates={[
+                    [
+                      p.challengeeLon ? p.challengeeLon : 0,
+                      p.challengeeLat ? p.challengeeLat : 0,
+                    ],
+                    path[idx + 1]
+                      ? [
+                          path[idx + 1].challengeeLon
+                            ? path[idx + 1].challengeeLon
+                            : 0,
+                          path[idx + 1].challengeeLat
+                            ? path[idx + 1].challengeeLat
+                            : 0,
+                        ]
+                      : [false],
+                  ]}
+                />
+              </Layer>
+              {p.witnesses.length > 0 &&
+                showWitnesses &&
+                p.witnesses.map((w) => {
+                  return (
+                    <span>
+                      <Tooltip title={animalHash(w.gateway)}>
+                        <Marker
+                          key={w.gateway}
+                          style={
+                            w.is_valid || w.isValid
+                              ? styles.witnessMarkerValid
+                              : styles.witnessMarkerInvalid
+                          }
+                          anchor="center"
+                          coordinates={[
+                            h3ToGeo(w.location)[1],
+                            h3ToGeo(w.location)[0],
+                          ]}
+                          onClick={() => router.push(`/hotspots/${w.gateway}`)}
+                        ></Marker>
+                      </Tooltip>
+                      <Layer
+                        key={'line-' + w.address}
+                        type="line"
+                        layout={{
+                          'line-cap': 'round',
+                          'line-join': 'round',
+                        }}
+                        paint={
+                          w.is_valid || w.isValid
+                            ? styles.witnessLineValid
+                            : styles.witnessLineInvalid
+                        }
+                      >
+                        <Feature
+                          coordinates={[
+                            [h3ToGeo(w.location)[1], h3ToGeo(w.location)[0]],
+                            [
+                              p.challengeeLon ? p.challengeeLon : 0,
+                              p.challengeeLat ? p.challengeeLat : 0,
+                            ],
+                          ]}
+                        />
+                      </Layer>
+                    </span>
+                  )
+                })}
+            </span>
+          )
+        })}
+      </Mapbox>
+    )
+  } else return null
 }
+
 export default PocMapbox

--- a/components/Txns/PocPath.js
+++ b/components/Txns/PocPath.js
@@ -35,13 +35,15 @@ class PocPath extends Component {
       return (
         <span>
           <PocMapbox path={path} showWitnesses={showWitnesses} />
-          <Checkbox
-            onChange={this.toggleWitnesses}
-            checked={showWitnesses}
-            style={{ color: 'black', float: 'right' }}
-          >
-            Show witnesses
-          </Checkbox>
+          {path.length > 0 && path[0].challengeeLon && path[0].challengeeLat && (
+            <Checkbox
+              onChange={this.toggleWitnesses}
+              checked={showWitnesses}
+              style={{ color: 'black', float: 'right' }}
+            >
+              Show witnesses
+            </Checkbox>
+          )}
         </span>
       )
     } else {

--- a/components/Txns/utils.js
+++ b/components/Txns/utils.js
@@ -4,24 +4,31 @@ const { formatToTimeZone } = require('date-fns-timezone')
 import { fromUnixTime } from 'date-fns'
 
 export const findBounds = (arrayOfLatsAndLons) => {
-  let minLon = arrayOfLatsAndLons[0].lng
-  let maxLon = arrayOfLatsAndLons[0].lng
-  let minLat = arrayOfLatsAndLons[0].lat
-  let maxLat = arrayOfLatsAndLons[0].lat
+  if (arrayOfLatsAndLons.length === 0) {
+    return [
+      [0, 0],
+      [0, 0],
+    ]
+  } else {
+    let minLon = arrayOfLatsAndLons[0].lng
+    let maxLon = arrayOfLatsAndLons[0].lng
+    let minLat = arrayOfLatsAndLons[0].lat
+    let maxLat = arrayOfLatsAndLons[0].lat
 
-  arrayOfLatsAndLons.map((m) => {
-    if (m.lng < minLon) minLon = m.lng
-    if (m.lng > maxLon) maxLon = m.lng
-    if (m.lat < minLat) minLat = m.lat
-    if (m.lat > maxLat) maxLat = m.lat
-  })
+    arrayOfLatsAndLons.map((m) => {
+      if (m.lng < minLon) minLon = m.lng
+      if (m.lng > maxLon) maxLon = m.lng
+      if (m.lat < minLat) minLat = m.lat
+      if (m.lat > maxLat) maxLat = m.lat
+    })
 
-  const mapBounds = [
-    [maxLon, maxLat],
-    [minLon, minLat],
-  ]
+    const mapBounds = [
+      [maxLon, maxLat],
+      [minLon, minLat],
+    ]
 
-  return mapBounds
+    return mapBounds
+  }
 }
 
 export const generateFriendlyTimestampString = (txnTime) => {

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -185,31 +185,33 @@ const HotspotView = ({ hotspot }) => {
             nearbyHotspots={nearbyHotspots}
             showNearbyHotspots={showNearbyHotspots}
           />
-          <div
-            style={{
-              textAlign: 'right',
-              paddingTop: 10,
-              color: 'white',
-            }}
-          >
-            <Checkbox
-              onChange={(e) => setShowNearbyHotspots(e.target.checked)}
-              checked={showNearbyHotspots}
-              style={{ color: 'white' }}
+          {hotspot.lng !== undefined && hotspot.lat !== undefined && (
+            <div
+              style={{
+                textAlign: 'right',
+                paddingTop: 10,
+                color: 'white',
+              }}
             >
-              Show nearby hotspots
-            </Checkbox>
-            <Checkbox
-              onChange={(e) => setShowWitnesses(e.target.checked)}
-              checked={showWitnesses}
-              style={{ color: 'white' }}
-            >
-              Show witnesses
-            </Checkbox>
-            <p style={{ marginBottom: '-20px' }}>
-              {formatLocation(hotspot?.geocode)}
-            </p>
-          </div>
+              <Checkbox
+                onChange={(e) => setShowNearbyHotspots(e.target.checked)}
+                checked={showNearbyHotspots}
+                style={{ color: 'white' }}
+              >
+                Show nearby hotspots
+              </Checkbox>
+              <Checkbox
+                onChange={(e) => setShowWitnesses(e.target.checked)}
+                checked={showWitnesses}
+                style={{ color: 'white' }}
+              >
+                Show witnesses
+              </Checkbox>
+              <p style={{ marginBottom: '-20px' }}>
+                {formatLocation(hotspot?.geocode)}
+              </p>
+            </div>
+          )}
 
           <Row style={{ paddingTop: 30 }}>
             <div

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -434,6 +434,10 @@ hr {
   cursor: pointer;
 }
 
+.no-location-set {
+  height: 400px;
+}
+
 @media screen and (max-width: 1200px) {
   .map-button {
     min-width: 0;
@@ -539,6 +543,9 @@ hr {
     padding: 20px;
   }
   .content-container-hotspot-view > .mapboxgl-map {
+    height: 200px;
+  }
+  .no-location-set {
     height: 200px;
   }
   #hotspot-checklist-container {


### PR DESCRIPTION
Added little tooltips so when you hover over a hotspot on the mapbox it'll show a tooltip with the animal name, and if you click on it it'll take you to that hotspot's detail page. This was added on the following pages' mapboxes:
- Hotspot detail page
- PoC Receipt transaction detail page
- Consensus transaction detail page

Visual example of what it looks like:
![Screen Shot 2021-01-21 at 5 39 42 PM](https://user-images.githubusercontent.com/10648471/105434114-cb4cb980-5c0f-11eb-8b00-75e06fac4a33.png)
![Screen Shot 2021-01-21 at 3 26 46 PM](https://user-images.githubusercontent.com/10648471/105434109-c982f600-5c0f-11eb-910f-779387d87ca8.png)
![Screen Shot 2021-01-21 at 5 39 36 PM](https://user-images.githubusercontent.com/10648471/105434113-cab42300-5c0f-11eb-8765-b34b1092d84f.png)


I also made it so the map that loads on a hotspot's detail page now uses the `findBounds` helper function to dynamically zoom and center the map based on all the nearby hotspots and witness hotspots. If there aren't any, it'll center on just the hotspot and at a decent zoom level.

I'm actually not sure about the dynamic zoom/centering though, since for some hotspots the "nearby" list actually extends quite far and makes the map pretty zoomed out. Maybe a hardcoded centering on the hotspot itself and a hardcoded zoom level is actually best... or some better rules around which other hotspots to include in the center/zoom logic.

And this PR also makes it so the hotspot detail page will just show an empty div for a hotspot with no location set (instead of loading a mapbox container with a marker at 0,0), it looks like this:
![Screen Shot 2021-01-21 at 5 46 05 PM](https://user-images.githubusercontent.com/10648471/105434552-a4db4e00-5c10-11eb-986f-2b607f5bd76d.png)


