### PR TITLE
Fix token burn bug in ActivityList

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -225,6 +225,8 @@ const columns = (ownerAddress) => {
                 .amount.toString(2)}
           </span>
         )
+      case 'token_burn_v1':
+        return <span>{txn.amount.toString(2)}</span>
       case 'rewards_v1':
         return <span>{txn.totalAmount.toString(2)}</span>
       case 'poc_receipts_v1':
@@ -256,7 +258,7 @@ const columns = (ownerAddress) => {
           return <span>{'+' + txn.amountToSeller.toString()}</span>
         }
       default:
-        return <span>{txn.amount}</span>
+        return <span>{txn.amount.toString(2)}</span>
     }
   }
 


### PR DESCRIPTION
Fixes #160 

Tiny change, but the default case in the switch statement for the "Details" column was breaking whenever a `token_burn_v1` would show up in the transactions in the `<ActivityList />` table

Example wallet: https://explorer.helium.com/accounts/13daGGWvDQyTyHFDCPz8zDSVTWgPNNfJ4oh31Teec4TRWfjMx53