### PR TITLE
Add links to next transaction and previous transaction buttons

### DIFF
--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -86,7 +86,7 @@ const findPreviousAndNext = async (transactions, hash) => {
 
     if (transaction.hash === hash) {
       const { value } = await generator.next()
-      next = value && value.hash
+      next = value?.hash
       break
     }
 

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -13,6 +13,7 @@ import AppLayout, { Content } from '../../components/AppLayout'
 import PieChart from '../../components/PieChart'
 import { getMetaTagsForTransaction } from '../../components/Txns/utils'
 import { Balance, CurrencyType } from '@helium/currency'
+import classNames from 'classnames'
 
 import {
   Fallback,
@@ -91,14 +92,20 @@ const findPreviousAndNext = async (transactions, hash) => {
   return { previous, next }
 }
 
-const ButtonPrevious = (props) => (
-  <a className="button" {...props}>
+const ButtonPrevious = ({ className, ...props }) => (
+  <a
+    className={classNames('button block-view-prev-button', className)}
+    {...props}
+  >
     <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous Transaction
   </a>
 )
 
-const ButtonNext = (props) => (
-  <a className="button" {...props}>
+const ButtonNext = ({ className, ...props }) => (
+  <a
+    className={classNames('button block-view-prev-button', className)}
+    {...props}
+  >
     Next Transaction <ForwardOutlined style={{ marginRight: '-6px' }} />
   </a>
 )
@@ -109,7 +116,7 @@ const Navigation = ({ Button, hash }) => {
       <Button />
     </Link>
   ) : (
-    <Button style={{ visibility: 'hidden' }} />
+    <Button className="hidden-width" />
   )
 }
 
@@ -215,15 +222,17 @@ const TxnView = ({ txn }) => {
             )}
           </div>
           <hr />
-          <div className="flexwrapper">
+          <div className="block-view-summary-container">
             <Navigation Button={ButtonPrevious} hash={navigation?.previous} />
 
-            <h3>
-              <ClockCircleOutlined
-                style={{ color: '#FFC769', marginRight: 4 }}
-              />
-              <Timestamp date={txn.time} />
-            </h3>
+            <span className="block-view-summary-info">
+              <h3>
+                <ClockCircleOutlined
+                  style={{ color: '#FFC769', marginRight: 4 }}
+                />
+                <Timestamp date={txn.time} />
+              </h3>
+            </span>
 
             <Navigation Button={ButtonNext} hash={navigation?.next} />
           </div>

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -103,7 +103,7 @@ const ButtonPrevious = ({ className, ...props }) => (
 
 const ButtonNext = ({ className, ...props }) => (
   <a
-    className={classNames('button block-view-prev-button', className)}
+    className={classNames('button block-view-next-button', className)}
     {...props}
   >
     Next Transaction <ForwardOutlined style={{ marginRight: '-6px' }} />

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -103,12 +103,19 @@ const TxnView = ({ txn }) => {
     txn.type === 'rewards_v1' &&
     new Balance(txn.totalAmount.integerBalance, CurrencyType.networkToken)
 
+  const [transactions, setTransactions] = useState()
   const [navigation, setNavigation] = useState()
+
   useEffect(async () => {
     const client = new Client()
-    const transactions = await client.block(txn.height).transactions.list()
-    setNavigation(await findPreviousAndNext(transactions, txn.hash))
-  }, [txn.hash])
+    setTransactions(await client.block(txn.height).transactions.list())
+  }, [txn.height])
+
+  useEffect(async () => {
+    if (transactions) {
+      setNavigation(await findPreviousAndNext(transactions, txn.hash))
+    }
+  }, [transactions, txn.hash])
 
   return (
     <AppLayout

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -4,8 +4,8 @@ import { Typography, Card } from 'antd'
 import {
   ClockCircleOutlined,
   WalletOutlined,
-  BackwardOutlined,
-  ForwardOutlined,
+  LeftOutlined,
+  RightOutlined,
 } from '@ant-design/icons'
 import Client from '@helium/http'
 import Timestamp from 'react-timestamp'
@@ -95,18 +95,20 @@ const findPreviousAndNext = async (transactions, hash) => {
 const ButtonPrevious = ({ className, ...props }) => (
   <a
     className={classNames('button block-view-prev-button', className)}
+    style={{ backgroundColor: '#35405b' }}
     {...props}
   >
-    <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous Transaction
+    <LeftOutlined style={{ marginleft: '-6px' }} /> Previous Transaction
   </a>
 )
 
 const ButtonNext = ({ className, ...props }) => (
   <a
     className={classNames('button block-view-next-button', className)}
+    style={{ backgroundColor: '#35405b' }}
     {...props}
   >
-    Next Transaction <ForwardOutlined style={{ marginRight: '-6px' }} />
+    Next Transaction <RightOutlined style={{ marginRight: '-6px' }} />
   </a>
 )
 

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -91,6 +91,28 @@ const findPreviousAndNext = async (transactions, hash) => {
   return { previous, next }
 }
 
+const ButtonPrevious = (props) => (
+  <a className="button" {...props}>
+    <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous Transaction
+  </a>
+)
+
+const ButtonNext = (props) => (
+  <a className="button" {...props}>
+    Next Transaction <ForwardOutlined style={{ marginRight: '-6px' }} />
+  </a>
+)
+
+const Navigation = ({ Button, hash }) => {
+  return hash ? (
+    <Link href={'/txns/' + hash}>
+      <Button />
+    </Link>
+  ) : (
+    <Button style={{ visibility: 'hidden' }} />
+  )
+}
+
 const TxnView = ({ txn }) => {
   const transactionMetaTags = getMetaTagsForTransaction(txn)
 
@@ -194,14 +216,7 @@ const TxnView = ({ txn }) => {
           </div>
           <hr />
           <div className="flexwrapper">
-            {navigation?.previous && (
-              <Link href={'/txns/' + navigation.previous}>
-                <a className="button">
-                  <BackwardOutlined style={{ marginleft: '-6px' }} /> Previous
-                  Transaction
-                </a>
-              </Link>
-            )}
+            <Navigation Button={ButtonPrevious} hash={navigation?.previous} />
 
             <h3>
               <ClockCircleOutlined
@@ -210,14 +225,7 @@ const TxnView = ({ txn }) => {
               <Timestamp date={txn.time} />
             </h3>
 
-            {navigation?.next && (
-              <Link href={'/txns/' + navigation.next}>
-                <a className="button">
-                  Next Transaction{' '}
-                  <ForwardOutlined style={{ marginRight: '-6px' }} />
-                </a>
-              </Link>
-            )}
+            <Navigation Button={ButtonNext} hash={navigation?.next} />
           </div>
         </div>
       </Content>

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -76,14 +76,9 @@ const rewardChart = (txn) => {
 
 const findPreviousAndNext = async (transactions, hash) => {
   let previous, next
-  let result = { done: false }
-
   const generator = transactions[Symbol.asyncIterator]()
 
-  while (!result.done) {
-    result = await generator.next()
-    const { value: transaction } = result
-
+  for await (const transaction of generator) {
     if (transaction.hash === hash) {
       const { value } = await generator.next()
       next = value?.hash

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -640,3 +640,10 @@ hr {
     padding-left: 18px;
   }
 }
+
+.hidden-width {
+  visibility: hidden;
+  height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
Fixes #38.

This is a very first prototype with a few issues:
- [x] The generator loop might not be the most idiomatic way to do things
- [x] The `transactions` in the `useEffect` should only be updated when `txn.height` changes, not when `txn.hash` changes (but `findPreviousAndNext` still needs to be called)
- [x] The flex design needs a bit of work, as the date ends up on the far left or far right when it's the first or last transaction of the block