### PR TITLE
Remove unused imports

### DIFF
--- a/components/AppLayout/AppLayout.js
+++ b/components/AppLayout/AppLayout.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Layout, Typography } from 'antd'
 import NavHeader from './NavHeader'
 import MetaTags from './MetaTags'
-import Typekit from 'react-typekit'
 
 const { Content, Footer } = Layout
 const { Text } = Typography

--- a/components/AppLayout/TopChart.js
+++ b/components/AppLayout/TopChart.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Row, Col, Typography, Tooltip } from 'antd'
+import { Row, Typography, Tooltip } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import useResponsive from './useResponsive'
 const { Title, Text } = Typography

--- a/components/BarChart.js
+++ b/components/BarChart.js
@@ -1,15 +1,5 @@
 import React, { PureComponent } from 'react'
-import {
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  Cell,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-} from 'recharts'
+import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts'
 
 const data = [
   {

--- a/components/BlocksChart.js
+++ b/components/BlocksChart.js
@@ -1,11 +1,6 @@
 import React, { Component } from 'react'
-import { Table, Typography, Tooltip } from 'antd'
-import Timestamp from 'react-timestamp'
+import { Table, Tooltip } from 'antd'
 import Client from '@helium/http'
-import LoadMoreButton from './LoadMoreButton'
-import classNames from 'classnames'
-
-const { Text } = Typography
 
 class BlocksList extends Component {
   state = {

--- a/components/GpsTag.js
+++ b/components/GpsTag.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react'
-import { Tag, Icon, Tooltip } from 'antd'
+import React from 'react'
+import { Tooltip } from 'antd'
 
 const GpsTag = ({ type }) => typeTag(type)
 

--- a/components/Home/HalvingCountdown.js
+++ b/components/Home/HalvingCountdown.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import { Row, Col, Typography } from 'antd'
 import Widget from './Widget'
 import Countdown from 'react-countdown'
-const { Title, Text } = Typography
 
 const HalveningCountdown = () => {
   return (

--- a/pages/blocks/[blockid].js
+++ b/pages/blocks/[blockid].js
@@ -1,4 +1,4 @@
-import { Typography, Table, Card, Skeleton } from 'antd'
+import { Typography, Table, Card } from 'antd'
 import Client from '@helium/http'
 import Timestamp from 'react-timestamp'
 import { TxnTag } from '../../components/Txns'

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Row, Typography, Checkbox, Tooltip, Skeleton } from 'antd'
+import { Row, Typography, Checkbox, Tooltip } from 'antd'
 import Client from '@helium/http'
 import algoliasearch from 'algoliasearch'
 import Fade from 'react-reveal/Fade'

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Row, Col, Typography, Card, Button } from 'antd'
+import { Row, Col, Card, Button } from 'antd'
 import AppLayout, { Content } from '../components/AppLayout'
 import { fetchMarket, useMarket } from '../data/market'
 import { fetchStats, useStats } from '../data/stats'
@@ -23,8 +23,6 @@ const MiniCoverageMap = dynamic(
     loading: () => <div style={{ height: '500px' }} />,
   },
 )
-
-const { Title, Text } = Typography
 
 const Index = ({
   market: initialMarket,

--- a/pages/market.js
+++ b/pages/market.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Typography, Card, Statistic, Row, Col, Tooltip } from 'antd'
+import { Row, Col } from 'antd'
 import AppLayout, { Content } from '../components/AppLayout'
 import { fetchMarket, useMarket } from '../data/market'
 import { fetchStats, useStats } from '../data/stats'
@@ -12,8 +12,6 @@ import Widget from '../components/Home/Widget'
 import TokenImg from '../public/images/token.svg'
 import round from 'lodash/round'
 import { getUnixTime, formatDistanceToNow } from 'date-fns'
-
-const { Title } = Typography
 
 function Market({
   market: initialMarket,


### PR DESCRIPTION
I know no one asked for this, but I noticed a few unused imports and thought that it's never bad to remove them, so I opened a PR.

I can also clean up a bit of the rest of the code if you'd like, for example other unused variables (that are not imports) or `useEffect(async () => {})` which are not idiomatic.