### PR TITLE
Hotfix: Hide reward scale for newly added hotspots

### DIFF
--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -307,57 +307,59 @@ const HotspotView = ({ hotspot }) => {
                       </Tooltip>
                     </div>
 
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        marginLeft: '10px',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        padding: '2px 10px',
-                        backgroundColor: '#182035',
-                        borderRadius: '20px',
-                      }}
-                    >
-                      <Tooltip
-                        placement="top"
-                        title={`Reward scale: ${hotspot.rewardScale}`}
+                    {hotspot.rewardScale && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'row',
+                          marginLeft: '10px',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          padding: '2px 10px',
+                          backgroundColor: '#182035',
+                          borderRadius: '20px',
+                        }}
                       >
-                        <span
-                          style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
+                        <Tooltip
+                          placement="top"
+                          title={`Reward scale: ${hotspot.rewardScale}`}
                         >
-                          <Hex
-                            width={10.5}
-                            height={12}
-                            fillColor={generateRewardScaleColor(
-                              hotspot.rewardScale,
-                            )}
-                          />
-                        </span>
-                      </Tooltip>
+                          <span
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            <Hex
+                              width={10.5}
+                              height={12}
+                              fillColor={generateRewardScaleColor(
+                                hotspot.rewardScale,
+                              )}
+                            />
+                          </span>
+                        </Tooltip>
 
-                      <Tooltip
-                        placement="top"
-                        title={`A Hotspot's own reward scale does not impact its earnings. Hotspots witnessing this Hotspot will see their rewards scaled up or down according to this Hotspot's reward scale.`}
-                      >
-                        <p
-                          style={{
-                            marginBottom: 0,
-                            color: '#8283B2',
-                            marginLeft: 8,
-                          }}
+                        <Tooltip
+                          placement="top"
+                          title={`A Hotspot's own reward scale does not impact its earnings. Hotspots witnessing this Hotspot will see their rewards scaled up or down according to this Hotspot's reward scale.`}
                         >
-                          {hotspot.rewardScale.toLocaleString(undefined, {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
-                        </p>
-                      </Tooltip>
-                    </div>
+                          <p
+                            style={{
+                              marginBottom: 0,
+                              color: '#8283B2',
+                              marginLeft: 8,
+                            }}
+                          >
+                            {hotspot.rewardScale.toLocaleString(undefined, {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </p>
+                        </Tooltip>
+                      </div>
+                    )}
                   </div>
                 </Fade>
                 <span className="hotspot-name">


### PR DESCRIPTION
For hotspots that were just added, a reward scale value doesn't show up, which currently breaks the hotspot detail page. I believe this is what @abhay  was pointing out in his comment here: https://github.com/helium/explorer/pull/165#issuecomment-770087372 (my bad!)