### PR TITLE
Fix for new hotspot on account page

### DIFF
--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -33,14 +33,20 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
       title: 'Reward Scale',
       dataIndex: 'rewardScale',
       key: 'rewardScale',
-      render: (data) => (
-        <span>
-          {data.toLocaleString(undefined, {
-            maximumFractionDigits: 2,
-            minimumFractionDigits: 2,
-          })}
-        </span>
-      ),
+      render: (data) => {
+        if (data) {
+          return (
+            <span>
+              {data.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 2,
+              })}
+            </span>
+          )
+        } else {
+          return <span>Not set</span>
+        }
+      },
     },
     {
       title: 'Rewards (24h)',


### PR DESCRIPTION
Same issue fixed by #178, but on the account page as well. For example: https://explorer.helium.com/accounts/12ymxmzj2PHBdPv8pJZreUfa6twLWwcS3Y3ZdnP8UuDgaeGmK7p