### PR TITLE
Make empty witness list look nicer

### DIFF
--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -90,7 +90,7 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
     <Content style={{ marginBottom: 20 }}>
       <Card loading={hotspotsLoading} title={'Hotspots'}>
         {hotspots.length == 0 ? (
-          <h2
+          <p
             style={{
               textAlign: 'center',
               marginTop: '0.5rem',
@@ -100,7 +100,7 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
             }}
           >
             Account has no hotspots
-          </h2>
+          </p>
         ) : (
           <Table
             dataSource={hotspots}

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -92,7 +92,7 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => (
     }
   >
     {witnesses.length === 0 ? (
-      <h2
+      <p
         style={{
           textAlign: 'center',
           marginTop: '0.5rem',
@@ -102,7 +102,7 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => (
         }}
       >
         Hotspot has no recent witnesses
-      </h2>
+      </p>
     ) : (
       <Table
         dataSource={witnesses}

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -91,15 +91,29 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => (
       </span>
     }
   >
-    <Table
-      dataSource={witnesses}
-      columns={columns}
-      size="small"
-      loading={witnessesLoading}
-      rowKey="name"
-      pagination={{ pageSize: 5, hideOnSinglePage: true }}
-      scroll={{ x: true }}
-    />
+    {witnesses.length === 0 ? (
+      <h2
+        style={{
+          textAlign: 'center',
+          marginTop: '0.5rem',
+          fontSize: '14px',
+          color: 'rgba(0, 0, 0, 0.25)',
+          padding: '20px',
+        }}
+      >
+        Hotspot has no recent witnesses
+      </h2>
+    ) : (
+      <Table
+        dataSource={witnesses}
+        columns={columns}
+        size="small"
+        loading={witnessesLoading}
+        rowKey="name"
+        pagination={{ pageSize: 5, hideOnSinglePage: true }}
+        scroll={{ x: true }}
+      />
+    )}
   </Card>
 )
 


### PR DESCRIPTION
Right now when a hotspot has no witnesses, the empty ant design table doesn't look very nice, and adds a horizontal scroll bar:

![Screen Shot 2021-02-04 at 2 56 01 PM](https://user-images.githubusercontent.com/10648471/106965854-2050fb00-66f9-11eb-86a9-b17c287c563d.png)

So this PR makes it look like this when there aren't any witnesses:
![Screen Shot 2021-02-04 at 3 01 24 PM](https://user-images.githubusercontent.com/10648471/106966290-e3d1cf00-66f9-11eb-9976-793c28bf469c.png)

Styling copied from very similar PR: #166

Fixes #96 