### PR TITLE
Simplify parseTxn and add the hash column

### DIFF
--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -168,9 +168,8 @@ export const parseTxn = async (
     return data
   }
 
-  const { feePaid = false, ...parsed } = data
   const timestamp = moment.unix(txn.time).toISOString()
-  const addDefaults = async (parsed) => ({
+  const addDefaults = async ({ feePaid = false, ...parsed }) => ({
     Date: timestamp,
     'Received Quantity': '',
     'Received From': '',
@@ -188,7 +187,7 @@ export const parseTxn = async (
     ...parsed,
   })
 
-  return Array.isArray(parsed)
-    ? Promise.all(parsed.map(addDefaults))
-    : addDefaults(parsed)
+  return Array.isArray(data)
+    ? Promise.all(data.map(addDefaults))
+    : addDefaults(data)
 }

--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -3,234 +3,11 @@ import animalHash from 'angry-purple-tiger'
 import Client from '@helium/http'
 import { Balance, CurrencyType } from '@helium/currency'
 
-export const parseTxn = async (
-  ownerAddress,
-  txn,
-  opts = { convertFee: true },
-) => {
-  const timestamp = moment.unix(txn.time).toISOString()
-  switch (txn.type) {
-    case 'rewards_v1': {
-      return txn.rewards.map(({ type, gateway, amount }) => {
-        const amountObject = new Balance(
-          amount.integerBalance,
-          CurrencyType.networkToken,
-        )
-        return {
-          Date: timestamp,
-          'Received Quantity': amountObject.toString(8).slice(0, -4),
-          'Received From': 'Helium Network',
-          'Received Currency': 'HNT',
-          'Sent Quantity': '',
-          'Sent To': '',
-          'Sent Currency': '',
-          'Fee Amount': '',
-          'Fee Currency': '',
-          Tag: 'mined',
-          Hotspot: gateway ? animalHash(gateway) : '',
-          'Reward Type': type,
-          Block: txn.height,
-        }
-      })
-    }
-    case 'payment_v1': {
-      const amountObject = new Balance(
-        txn.amount.integerBalance,
-        CurrencyType.networkToken,
-      )
-      if (ownerAddress === txn.payer) {
-        return {
-          Date: timestamp,
-          'Received Quantity': '',
-          'Received From': '',
-          'Received Currency': '',
-          'Sent Quantity': amountObject.toString(8).slice(0, -4),
-          'Sent To': txn.payee,
-          'Sent Currency': 'HNT',
-          'Fee Amount': await getFee(txn, opts.convertFee),
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'payment',
-          Hotspot: '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      } else {
-        return {
-          Date: timestamp,
-          'Received Quantity': amountObject.toString(8).slice(0, -4),
-          'Received From': txn.payer,
-          'Received Currency': 'HNT',
-          'Sent Quantity': '',
-          'Sent To': '',
-          'Sent Currency': '',
-          'Fee Amount': 0,
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'payment',
-          Hotspot: '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      }
-    }
-    case 'payment_v2': {
-      if (ownerAddress === txn.payer) {
-        const formatMultiplePayeesString = (payments) => {
-          const multiplePayees = []
-          payments.map((p) => {
-            multiplePayees.push(p.payee)
-          })
-          return multiplePayees.join(', ')
-        }
-        const amountObject = new Balance(
-          txn.totalAmount.integerBalance,
-          CurrencyType.networkToken,
-        )
-        return {
-          Date: timestamp,
-          'Received Quantity': '',
-          'Received From': '',
-          'Received Currency': '',
-          'Sent Quantity': amountObject.toString(8).slice(0, -4),
-          'Sent To':
-            txn.payments.length === 1
-              ? txn.payments[0].payee
-              : formatMultiplePayeesString(txn.payments),
-          'Sent Currency': 'HNT',
-          'Fee Amount': await getFee(txn, opts.convertFee),
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'payment',
-          Hotspot: '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      } else {
-        const amountObject = new Balance(
-          txn.payments.find(
-            (p) => p.payee === ownerAddress,
-          ).amount.integerBalance,
-          CurrencyType.networkToken,
-        )
-        return {
-          Date: timestamp,
-          'Received Quantity': amountObject.toString(8).slice(0, -4),
-          'Received From': txn.payer,
-          'Received Currency': 'HNT',
-          'Sent Quantity': '',
-          'Sent To': '',
-          'Sent Currency': '',
-          'Fee Amount': 0,
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'payment',
-          Hotspot: '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      }
-    }
-    case 'transfer_hotspot_v1': {
-      const amountToSellerObject = new Balance(
-        txn.amountToSeller.integerBalance,
-        CurrencyType.networkToken,
-      )
-      if (ownerAddress === txn.buyer) {
-        return {
-          Date: timestamp,
-          'Received Quantity': '',
-          'Received From': '',
-          'Received Currency': '',
-          'Sent Quantity': amountToSellerObject.toString().slice(0, -4),
-          'Sent To': txn.seller,
-          'Sent Currency': 'HNT',
-          'Fee Amount': await getFee(txn, opts.convertFee),
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'gateway transfer payment',
-          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      } else {
-        return {
-          Date: timestamp,
-          'Received Quantity': amountToSellerObject.toString().slice(0, -4),
-          'Received From': txn.buyer,
-          'Received Currency': 'HNT',
-          'Sent Quantity': '',
-          'Sent To': '',
-          'Sent Currency': '',
-          'Fee Amount': 0,
-          'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-          Tag: 'gateway transfer payment',
-          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
-          'Reward Type': '',
-          Block: txn.height,
-        }
-      }
-    }
-    case 'add_gateway_v1': {
-      return {
-        Date: timestamp,
-        'Received Quantity': '',
-        'Received From': '',
-        'Received Currency': '',
-        'Sent Quantity':
-          txn.payer === null
-            ? await getFee(
-                {
-                  height: txn.height,
-                  fee: {
-                    integerBalance: txn.stakingFee,
-                  },
-                },
-                opts.convertFee,
-              )
-            : 0,
-        'Sent To': txn.payer === null ? 'Helium Network' : '',
-        'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
-        'Fee Amount':
-          txn.payer === null ? await getFee(txn, opts.convertFee) : 0,
-        'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-        Tag: 'add gateway payment',
-        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
-        'Reward Type': '',
-        Block: txn.height,
-      }
-    }
-    case 'assert_location_v1': {
-      return {
-        Date: timestamp,
-        'Received Quantity': '',
-        'Received From': '',
-        'Received Currency': '',
-        'Sent Quantity':
-          txn.payer === null
-            ? await getFee(
-                {
-                  height: txn.height,
-                  fee: {
-                    integerBalance: txn.stakingFee,
-                  },
-                },
-                opts.convertFee,
-              )
-            : 0,
-        'Sent To': txn.payer === null ? 'Helium Network' : '',
-        'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
-        'Fee Amount':
-          txn.payer === null ? await getFee(txn, opts.convertFee) : 0,
-        'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
-        Tag: 'assert location payment',
-        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
-        'Reward Type': '',
-        Block: txn.height,
-      }
-    }
-    default: {
-      return null
-    }
-  }
-}
-
 const getFee = async ({ height, fee }, convertFee) => {
+  if (!fee) {
+    return 0
+  }
+
   if (convertFee) {
     const client = new Client()
     const { price: oraclePrice } = await client.oracle.getPriceAtBlock(height)
@@ -242,5 +19,174 @@ const getFee = async ({ height, fee }, convertFee) => {
     return output
   }
 
-  return fee === 0 ? 0 : fee.integerBalance
+  return fee.integerBalance
+}
+
+const formatMultiplePayeesString = (payments) => {
+  return payments.map((p) => p.payee).join(', ')
+}
+
+const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
+  switch (txn.type) {
+    case 'rewards_v1': {
+      return txn.rewards.map(({ type, gateway, amount }) => {
+        const amountObject = new Balance(
+          amount.integerBalance,
+          CurrencyType.networkToken,
+        )
+        return {
+          'Received Quantity': amountObject.toString(8).slice(0, -4),
+          'Received From': 'Helium Network',
+          'Received Currency': 'HNT',
+          Tag: 'mined',
+          Hotspot: gateway ? animalHash(gateway) : '',
+          'Reward Type': type,
+        }
+      })
+    }
+    case 'payment_v1': {
+      const amountObject = new Balance(
+        txn.amount.integerBalance,
+        CurrencyType.networkToken,
+      )
+      const fromMe = ownerAddress === txn.payer
+      const type = fromMe ? 'Sent' : 'Received'
+      return {
+        [`${type} Quantity`]: amountObject.toString(8).slice(0, -4),
+        [`${type} ${fromMe ? 'To' : 'From'}`]: txn.payee,
+        [`${type} Currency`]: 'HNT',
+        Tag: 'payment',
+      }
+    }
+    case 'payment_v2': {
+      if (ownerAddress === txn.payer) {
+        const amountObject = new Balance(
+          txn.totalAmount.integerBalance,
+          CurrencyType.networkToken,
+        )
+        return {
+          'Sent Quantity': amountObject.toString(8).slice(0, -4),
+          'Sent To':
+            txn.payments.length === 1
+              ? txn.payments[0].payee
+              : formatMultiplePayeesString(txn.payments),
+          'Sent Currency': 'HNT',
+          Tag: 'payment',
+        }
+      } else {
+        const amountObject = new Balance(
+          txn.payments.find(
+            (p) => p.payee === ownerAddress,
+          ).amount.integerBalance,
+          CurrencyType.networkToken,
+        )
+        return {
+          'Received Quantity': amountObject.toString(8).slice(0, -4),
+          'Received From': txn.payer,
+          'Received Currency': 'HNT',
+          Tag: 'payment',
+        }
+      }
+    }
+    case 'transfer_hotspot_v1': {
+      const amountToSellerObject = new Balance(
+        txn.amountToSeller.integerBalance,
+        CurrencyType.networkToken,
+      )
+      if (ownerAddress === txn.buyer) {
+        return {
+          'Sent Quantity': amountToSellerObject.toString().slice(0, -4),
+          'Sent To': txn.seller,
+          'Sent Currency': 'HNT',
+          Tag: 'gateway transfer payment',
+          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
+        }
+      } else {
+        return {
+          'Received Quantity': amountToSellerObject.toString().slice(0, -4),
+          'Received From': txn.buyer,
+          'Received Currency': 'HNT',
+          Tag: 'gateway transfer payment',
+          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
+        }
+      }
+    }
+    case 'add_gateway_v1': {
+      return {
+        'Sent Quantity':
+          txn.payer === null
+            ? await getFee(
+                {
+                  height: txn.height,
+                  fee: {
+                    integerBalance: txn.stakingFee,
+                  },
+                },
+                opts.convertFee,
+              )
+            : 0,
+        'Sent To': txn.payer === null ? 'Helium Network' : '',
+        'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
+        Tag: 'add gateway payment',
+        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
+      }
+    }
+    case 'assert_location_v1': {
+      return {
+        'Sent Quantity':
+          txn.payer === null
+            ? await getFee(
+                {
+                  height: txn.height,
+                  fee: {
+                    integerBalance: txn.stakingFee,
+                  },
+                },
+                opts.convertFee,
+              )
+            : 0,
+        'Sent To': txn.payer === null ? 'Helium Network' : '',
+        'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
+        Tag: 'assert location payment',
+        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
+      }
+    }
+    default: {
+      return null
+    }
+  }
+}
+
+export const parseTxn = async (
+  ownerAddress,
+  txn,
+  opts = { convertFee: true },
+) => {
+  const parsed = await parse(ownerAddress, txn, opts)
+  if (!parsed) {
+    return parsed
+  }
+
+  const timestamp = moment.unix(txn.time).toISOString()
+  const addDefaults = async (parsed) => ({
+    Date: timestamp,
+    'Received Quantity': '',
+    'Received From': '',
+    'Received Currency': '',
+    'Sent Quantity': '',
+    'Sent To': '',
+    'Sent Currency': '',
+    'Fee Amount': await getFee(txn, opts.convertFee),
+    'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
+    Tag: '',
+    Hotspot: '',
+    'Reward Type': '',
+    Block: txn.height,
+    Hash: txn.hash,
+    ...parsed,
+  })
+
+  return Array.isArray(parsed)
+    ? Promise.all(parsed.map(addDefaults))
+    : addDefaults(parsed)
 }

--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -99,7 +99,6 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           'Sent To': txn.seller,
           'Sent Currency': 'HNT',
           Tag: 'gateway transfer payment',
-          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
         }
       } else {
         return {
@@ -107,7 +106,6 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           'Received From': txn.buyer,
           'Received Currency': 'HNT',
           Tag: 'gateway transfer payment',
-          Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
         }
       }
     }
@@ -128,7 +126,6 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
         'Sent To': txn.payer === null ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
         Tag: 'add gateway payment',
-        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
       }
     }
     case 'assert_location_v1': {
@@ -148,7 +145,6 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
         'Sent To': txn.payer === null ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
         Tag: 'assert location payment',
-        Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
       }
     }
     default: {
@@ -179,7 +175,7 @@ export const parseTxn = async (
     'Fee Amount': await getFee(txn, opts.convertFee),
     'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
     Tag: '',
-    Hotspot: '',
+    Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
     'Reward Type': '',
     Block: txn.height,
     Hash: txn.hash,


### PR DESCRIPTION
This simplifies the function quite a bit by removing quite a few lines. It should also be less error prone, as constant columns don't need to be repeated anymore. Actually, I'm not even sure if it's required to have all columns repeated constantly, but I left them in there in order not to change the function's output.

I also added the hash column while I was at it, which was asked in #125.

I'm not entirely sure if everything still works as expected, I guess I could try by exporting one year of a big account and making sure that the result is the same.