### PR TITLE
Remove date-fns-timezone

### DIFF
--- a/components/Txns/utils.js
+++ b/components/Txns/utils.js
@@ -34,7 +34,7 @@ const convertToUtc = (date) => addMinutes(date, date.getTimezoneOffset())
 
 export const generateFriendlyTimestampString = (txnTime) => {
   const timestampInput = convertToUtc(fromUnixTime(txnTime))
-  const date = format(timestampInput, 'MMMM Do, yyyy')
+  const date = format(timestampInput, 'MMMM do, yyyy')
   const time = format(timestampInput, 'h:mm a')
 
   return `on ${date} at ${time} UTC`

--- a/components/Txns/utils.js
+++ b/components/Txns/utils.js
@@ -1,7 +1,6 @@
 import animalHash from 'angry-purple-tiger'
 import { Balance, CurrencyType } from '@helium/currency'
-const { formatToTimeZone } = require('date-fns-timezone')
-import { fromUnixTime } from 'date-fns'
+import { fromUnixTime, format, addMinutes } from 'date-fns'
 
 export const findBounds = (arrayOfLatsAndLons) => {
   if (arrayOfLatsAndLons.length === 0) {
@@ -31,19 +30,14 @@ export const findBounds = (arrayOfLatsAndLons) => {
   }
 }
 
-export const generateFriendlyTimestampString = (txnTime) => {
-  const timestampInput = fromUnixTime(txnTime)
-  const date = formatToTimeZone(timestampInput, 'MMMM Do, YYYY', {
-    timeZone: 'Etc/UTC',
-    convertTimeZone: true,
-  })
-  const time = formatToTimeZone(timestampInput, 'h:mm A', {
-    timeZone: 'Etc/UTC',
-    convertTimeZone: true,
-  })
+const convertToUtc = (date) => addMinutes(date, date.getTimezoneOffset())
 
-  const timestampString = `on ${date} at ${time} UTC`
-  return timestampString
+export const generateFriendlyTimestampString = (txnTime) => {
+  const timestampInput = convertToUtc(fromUnixTime(txnTime))
+  const date = format(timestampInput, 'MMMM Do, yyyy')
+  const time = format(timestampInput, 'h:mm a')
+
+  return `on ${date} at ${time} UTC`
 }
 
 export const getMetaTagsForTransaction = (txn, isFallback) => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "camelcase-keys": "^6.2.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",
-    "date-fns-timezone": "^0.1.4",
     "export-to-csv": "^0.2.1",
     "geojson": "^0.5.0",
     "h3-js": "3.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,11 +5183,6 @@ commander@2, commander@^2.11.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
-
 commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -5951,19 +5946,6 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
-
-date-fns-timezone@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-fns-timezone/-/date-fns-timezone-0.1.4.tgz#bc9fac78aae9a7bdb847f3ab4ce6d14f9fb9a55f"
-  integrity sha512-npnZn1eIeHV8A3Hqw86mn6CjH+qMe0TSCs4anpD4Rouf+mE9eIJuaHviIpNmGL9GiDmcUoiaKdkX5ihf+yZQZA==
-  dependencies:
-    date-fns "^1.29.0"
-    timezone-support "^1.5.5"
-
-date-fns@^1.29.0:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-fns@^2.15.0, date-fns@^2.16.1:
   version "2.16.1"
@@ -14581,13 +14563,6 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-timezone-support@^1.5.5:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-1.8.1.tgz#0a8c04d0614be6fccdd2280aaad5072fa5d31e5f"
-  integrity sha512-+pKzxoUe4PZXaQcswceJlA+69oRyyu1uivnYKdpsC7eGzZiuvTLbU4WYPqTKslEsoSvjN8k/u/6qNfGikBB/wA==
-  dependencies:
-    commander "2.19.0"
 
 timsort@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This replaces `date-fns-timezone` with native code and two `date-fns` functions, dropping 36 kB from `/blocks/[blockid]` and `/txns/[txnid]`.

It also adds 0.1 kB, although I'm not quite sure why and would like to fix that.