### PR TITLE
Remove moment

### DIFF
--- a/components/Antd/config.js
+++ b/components/Antd/config.js
@@ -1,0 +1,109 @@
+import {
+  getDay,
+  getYear,
+  getMonth,
+  getDate,
+  endOfMonth,
+  getHours,
+  getMinutes,
+  getSeconds,
+  addYears,
+  addMonths,
+  addDays,
+  setYear,
+  setMonth,
+  setDate,
+  setHours,
+  setMinutes,
+  setSeconds,
+  isAfter,
+  isValid,
+  getWeek,
+  startOfWeek,
+  format as formatDate,
+  parse as parseDate,
+} from 'date-fns'
+import enUS from 'date-fns/locale/en-US'
+
+const localeParse = (format) => {
+  return format
+    .replace(/Y/g, 'y')
+    .replace(/D/g, 'd')
+    .replace(/gggg/, 'yyyy')
+    .replace(/g/g, 'G')
+    .replace(/([Ww])o/g, 'wo')
+}
+
+const generateConfig = {
+  // get
+  getNow: () => new Date(),
+  getFixedDate: (string) => new Date(string),
+  getEndDate: (date) => endOfMonth(date),
+  getWeekDay: (date) => getDay(date),
+  getYear: (date) => getYear(date),
+  getMonth: (date) => getMonth(date),
+  getDate: (date) => getDate(date),
+  getHour: (date) => getHours(date),
+  getMinute: (date) => getMinutes(date),
+  getSecond: (date) => getSeconds(date),
+
+  // set
+  addYear: (date, diff) => addYears(date, diff),
+  addMonth: (date, diff) => addMonths(date, diff),
+  addDate: (date, diff) => addDays(date, diff),
+  setYear: (date, year) => setYear(date, year),
+  setMonth: (date, month) => setMonth(date, month),
+  setDate: (date, num) => setDate(date, num),
+  setHour: (date, hour) => setHours(date, hour),
+  setMinute: (date, minute) => setMinutes(date, minute),
+  setSecond: (date, second) => setSeconds(date, second),
+
+  // Compare
+  isAfter: (date1, date2) => isAfter(date1, date2),
+  isValidate: (date) => isValid(date),
+
+  locale: {
+    getWeekFirstDay: (locale) => {
+      return enUS.options.weekStartsOn
+    },
+    getWeekFirstDate: (locale, date) => {
+      return startOfWeek(date, { locale: enUS })
+    },
+    getWeek: (locale, date) => {
+      return getWeek(date, { locale: enUS })
+    },
+    getShortWeekDays: (locale) => {
+      return Array.from({ length: 7 }).map((_, i) =>
+        enUS.localize.day(i, { width: 'short' }),
+      )
+    },
+    getShortMonths: (locale) => {
+      return Array.from({ length: 12 }).map((_, i) =>
+        enUS.localize.month(i, { width: 'abbreviated' }),
+      )
+    },
+    format: (locale, date, format) => {
+      if (!isValid(date)) {
+        return null
+      }
+      return formatDate(date, localeParse(format), {
+        locale: enUS,
+      })
+    },
+    parse: (locale, text, formats) => {
+      for (let i = 0; i < formats.length; i += 1) {
+        const format = localeParse(formats[i])
+        const formatText = text
+        const date = parseDate(formatText, format, new Date(), {
+          locale: enUS,
+        })
+        if (isValid(date)) {
+          return date
+        }
+      }
+      return null
+    },
+  },
+}
+
+export default generateConfig

--- a/components/Antd/config.js
+++ b/components/Antd/config.js
@@ -1,3 +1,5 @@
+// This file is a copy of https://github.com/react-component/picker/blob/26726d25a031275375b8cbf92f960e9594efa45c/src/generate/dateFns.ts
+// But it only supports the en_US locale.
 import {
   getDay,
   getYear,

--- a/components/Antd/index.js
+++ b/components/Antd/index.js
@@ -1,0 +1,4 @@
+import dateFnsGenerateConfig from './config'
+import generatePicker from 'antd/lib/date-picker/generatePicker'
+
+export const DatePicker = generatePicker(dateFnsGenerateConfig)

--- a/components/ExportCSV/ExportForm.js
+++ b/components/ExportCSV/ExportForm.js
@@ -1,6 +1,16 @@
 import React from 'react'
-import { DatePicker, Typography, Radio, Checkbox } from 'antd'
-import moment from 'moment'
+import { Typography, Radio, Checkbox } from 'antd'
+import { DatePicker } from '../../components/Antd'
+import {
+  startOfDay,
+  startOfMonth,
+  startOfYear,
+  endOfMonth,
+  endOfYear,
+  subMonths,
+  subYears,
+} from 'date-fns'
+
 const { RangePicker } = DatePicker
 const { Text } = Typography
 
@@ -33,6 +43,8 @@ const ExportForm = ({ onDateChange, onTxnChange, onFeeChange, type }) => {
       break
   }
 
+  const now = new Date()
+
   return (
     <div>
       <InputGroup>
@@ -42,16 +54,16 @@ const ExportForm = ({ onDateChange, onTxnChange, onFeeChange, type }) => {
         <div>
           <RangePicker
             ranges={{
-              Today: [moment().startOf('day'), moment()],
-              'This Month': [moment().startOf('month'), moment()],
+              Today: [startOfDay(now), now],
+              'This Month': [startOfMonth(now), now],
               'Last Month': [
-                moment().subtract(1, 'months').startOf('month'),
-                moment().subtract(1, 'months').endOf('month'),
+                startOfMonth(subMonths(now, 1)),
+                endOfMonth(subMonths(now, 1)),
               ],
-              'This Year': [moment().startOf('year'), moment()],
+              'This Year': [startOfYear(now), now],
               'Last Year': [
-                moment().subtract(1, 'years').startOf('year'),
-                moment().subtract(1, 'years').endOf('year'),
+                startOfYear(subYears(now, 1)),
+                endOfYear(subYears(now, 1)),
               ],
             }}
             onChange={onDateChange}

--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -1,7 +1,7 @@
-import moment from 'moment'
 import animalHash from 'angry-purple-tiger'
 import Client from '@helium/http'
 import { Balance, CurrencyType } from '@helium/currency'
+import { fromUnixTime } from 'date-fns'
 
 const getFee = async ({ height, fee }, convertFee) => {
   if (!fee) {
@@ -168,7 +168,7 @@ export const parseTxn = async (
     return data
   }
 
-  const timestamp = moment.unix(txn.time).toISOString()
+  const timestamp = fromUnixTime(txn.time).toISOString()
   const addDefaults = async ({ feePaid = false, ...parsed }) => ({
     Date: timestamp,
     'Received Quantity': '',


### PR DESCRIPTION
`date-fns` was already used throughout the codebase, and `moment` is quite big and in maintenance mode (https://github.com/moment/moment). Thus, it would be nice to remove `moment` entirely, while significantly reducing the bundle size.

Caveat: using `date-fns` actually somehow results in a bigger bundle if all locales are imported. However, I think that right now the explorer uses the `en_US` locale no matter what, so I only imported that specific locale. With that in mind, the following bundle sizes were reduces by 61 kB:

- `/accounts/[accountid]`
- `/hotspots/[hotspotid]`

Also, `antd` relies on `moment`, but has some documentation on how to get rid of it: https://ant.design/docs/react/replace-moment#Use-date-fns