### PR TITLE
Add optional oracle price column to CSV export

### DIFF
--- a/components/ExportCSV/ExportForm.js
+++ b/components/ExportCSV/ExportForm.js
@@ -14,7 +14,13 @@ const InputGroup = ({ children }) => (
   <div style={{ margin: '0 0 12px 0' }}>{children}</div>
 )
 
-const ExportForm = ({ onDateChange, onTxnChange, onFeeChange, type }) => {
+const ExportForm = ({
+  onDateChange,
+  onTxnChange,
+  onFeeChange,
+  onIncludeOraclePriceChange,
+  type,
+}) => {
   let options
 
   switch (type) {
@@ -85,6 +91,19 @@ const ExportForm = ({ onDateChange, onTxnChange, onFeeChange, type }) => {
           </div>
         </InputGroup>
       )}
+      <InputGroup>
+        <Text strong>Include Oracle Price for each transaction</Text>
+        <div>
+          <Radio.Group onChange={onIncludeOraclePriceChange} defaultValue="no">
+            <Radio style={radioStyle} value="no">
+              No
+            </Radio>
+            <Radio style={radioStyle} value="yes">
+              Yes (CSV will take longer to generate)
+            </Radio>
+          </Radio.Group>
+        </div>
+      </InputGroup>
     </div>
   )
 }

--- a/components/ExportCSV/ExportModal.js
+++ b/components/ExportCSV/ExportModal.js
@@ -15,6 +15,7 @@ const initialState = {
   endDate: moment().startOf('day'),
   txn: ['payment', 'reward'],
   fee: 'dc',
+  includeOraclePrice: 'no',
   lastTxnTime: moment().unix(),
 }
 
@@ -47,10 +48,12 @@ class ExportModal extends React.Component {
 
   onTxnChange = (txn) => this.setState({ txn })
   onFeeChange = (e) => this.setState({ fee: e.target.value })
+  onIncludeOraclePriceChange = (e) =>
+    this.setState({ includeOraclePrice: e.target.value })
 
   handleExportCsv = async () => {
     const { address, type } = this.props
-    const { startDate, endDate, txn, fee } = this.state
+    const { startDate, endDate, txn, fee, includeOraclePrice } = this.state
 
     const filterTypes = []
     if (txn.includes('payment')) filterTypes.push('payment_v1', 'payment_v2')
@@ -89,7 +92,10 @@ class ExportModal extends React.Component {
       if (txn.time <= endDate.unix()) {
         data.push(
           ...[].concat(
-            await parseTxn(address, txn, { convertFee: fee === 'hnt' }),
+            await parseTxn(address, txn, {
+              convertFee: fee === 'hnt',
+              includeOraclePrice: includeOraclePrice === 'yes',
+            }),
           ),
         )
       }
@@ -147,6 +153,7 @@ class ExportModal extends React.Component {
               onDateChange={this.onDateChange}
               onTxnChange={this.onTxnChange}
               onFeeChange={this.onFeeChange}
+              onIncludeOraclePriceChange={this.onIncludeOraclePriceChange}
             />
           )}
         </Modal>


### PR DESCRIPTION
This PR adds an optional column to the CSV export for an account or a hotspot page, which gives the oracle price in USD at the block height of each transaction

It adds the option to the modal like this:

(account)
![Screen Shot 2021-02-09 at 12 08 46 PM](https://user-images.githubusercontent.com/10648471/107422385-cc1a9200-6acf-11eb-93f9-5d678f53aead.png)

(hotspot)
![Screen Shot 2021-02-09 at 12 10 05 PM](https://user-images.githubusercontent.com/10648471/107422400-d0df4600-6acf-11eb-9d95-15ee5c643999.png)


And if selected, adds this column to the CSV:
![Screen Shot 2021-02-09 at 12 11 09 PM](https://user-images.githubusercontent.com/10648471/107422487-f2403200-6acf-11eb-93bf-2c37339d2c11.png)

