### PR TITLE
Fix staking fee display on assert location transactions

### DIFF
--- a/components/Txns/AssertLocationV1.js
+++ b/components/Txns/AssertLocationV1.js
@@ -27,7 +27,7 @@ const AssertLocationV1 = ({ txn }) => {
     setHotspot(hotspot)
   }, [])
 
-  const stakingFee = new Balance(
+  const stakingFeeObject = new Balance(
     txn.stakingFee.integerBalance,
     CurrencyType.dataCredit,
   )
@@ -141,7 +141,7 @@ const AssertLocationV1 = ({ txn }) => {
               justifyContent: 'flex-start',
             }}
           >
-            {stakingFee.toString()}
+            {stakingFeeObject.toString()}
           </span>
         </Descriptions.Item>
         <Descriptions.Item label="Staking Fee Payer" span={3}>

--- a/components/Txns/AssertLocationV1.js
+++ b/components/Txns/AssertLocationV1.js
@@ -27,7 +27,10 @@ const AssertLocationV1 = ({ txn }) => {
     setHotspot(hotspot)
   }, [])
 
-  const stakingFee = new Balance(txn.stakingFee, CurrencyType.dataCredit)
+  const stakingFee = new Balance(
+    txn.stakingFee.integerBalance,
+    CurrencyType.dataCredit,
+  )
   const stakingFeePayer =
     txn.payer === txn.owner || txn.payer === null ? txn.owner : txn.payer
 


### PR DESCRIPTION
Staking Fee was showing up as `NaN DC` on assert_location_v1 transactions:
![Screen Shot 2021-02-09 at 5 53 52 PM](https://user-images.githubusercontent.com/10648471/107453433-cb99ef80-6aff-11eb-9529-729cb4716b5b.png)

https://explorer.helium.com/txns/Jg0qiAjQBa1nCnMCoCUcKVikfSTFPh15Qj88BGC9JKE

I think it's because `helium-js` used to send an integer for `stakingFee`, but now sends a full Balance object

this PR makes that field show `1,000,000 DC` again:

![Screen Shot 2021-02-09 at 5 52 40 PM](https://user-images.githubusercontent.com/10648471/107453369-b2913e80-6aff-11eb-88f7-f422f5c74dea.png)
