### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:lts-alpine
 
 ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
-RUN apk update && \
-    apk add --no-cache git
+RUN apk add --no-cache git
 
 COPY package*.json ./
 RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
 RUN apk add --no-cache git
 
 COPY package*.json ./
+COPY yarn.lock
 
 RUN yarn --frozen-lockfile
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:lts-alpine
+
+ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
+RUN apk update && \
+    apk add git
+
+COPY package*.json ./
+RUN yarn
+COPY . .
+
+EXPOSE 3000
+CMD [ "npm", "run", "dev" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:lts-alpine
 ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
 RUN apk add --no-cache git
 
-COPY package*.json ./
-COPY yarn.lock
+COPY package.json yarn.lock ./
 
 RUN yarn --frozen-lockfile
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:lts-alpine
 
 ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
 RUN apk update && \
-    apk add git
+    apk add --no-cache git
 
 COPY package*.json ./
 RUN yarn
 COPY . .
 
 EXPOSE 3000
-CMD [ "npm", "run", "dev" ]
+CMD [ "yarn", "dev" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV NEXT_PUBLIC_MAPBOX_KEY $NEXT_PUBLIC_MAPBOX_KEY
 RUN apk add --no-cache git
 
 COPY package*.json ./
-RUN yarn
+
+RUN yarn --frozen-lockfile
 COPY . .
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You need to adapt your *NEXT_PUBLIC_MAPBOX_KEY* to run this container
 
 ## Questions
 
-If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the #explorer-dev channel in [the official Helium Community Discord server](http://discord.gg/helium)!
+If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the `#explorer-dev` channel in [the official Helium Community Discord server](http://discord.gg/helium)!
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Code that powers the official [Helium Blockchain Explorer](https://explorer.heli
 
 Any and all contributions from the community are encouraged.
 
-- Guidelines for how to contribute to this repository [are here](https://github.com/helium/explorer/blob/master/CONTRIBUTING.md).
+- Guidelines for how to contribute to this repository [are here](https://github.com/helium/explorer/blob/master/CONTRIBUTING.md);
 - Discussion about the development and usage of the Helium Blockchain Explorer takes place in the [official Helium Discord Server](https://discord.gg/helium), specifically in the `#explorer-dev` channel. Join us!
 - For a list of issues and prioritization, please go to our [Project page](https://github.com/orgs/helium/projects/9).
 
@@ -57,9 +57,18 @@ git checkout -b witness-list-enhancements
 
 6. Push your changes to GitHub and create a PR against the master branch, linking the PR to any relevant issues.
 
+## Deploy with Docker
+
+```bash
+docker run -e NEXT_PUBLIC_MAPBOX_KEY="CHANGE_ME" -p 3000:3000 ftx514/helium-explorer:latest
+```
+
+You need to adapt your *NEXT_PUBLIC_MAPBOX_KEY* to run this container
+
+
 ## Questions
 
-If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the `#explorer-dev` channel in [the official Helium Community Discord server](http://discord.gg/helium)!
+If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the #explorer-dev channel in [the official Helium Community Discord server](http://discord.gg/helium)!
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ git checkout -b witness-list-enhancements
 ## Deploy with Docker
 
 ```bash
-docker run -e NEXT_PUBLIC_MAPBOX_KEY="CHANGE_ME" -p 3000:3000 ftx514/helium-explorer:latest
+docker build -t helium-explorer .
+docker run -e NEXT_PUBLIC_MAPBOX_KEY="CHANGE_ME" -p 3000:3000 helium-explorer
 ```
 
 You need to adapt your *NEXT_PUBLIC_MAPBOX_KEY* to run this container

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Code that powers the official [Helium Blockchain Explorer](https://explorer.heli
 
 Any and all contributions from the community are encouraged.
 
-- Guidelines for how to contribute to this repository [are here](https://github.com/helium/explorer/blob/master/CONTRIBUTING.md);
+- Guidelines for how to contribute to this repository [are here](https://github.com/helium/explorer/blob/master/CONTRIBUTING.md).
 - Discussion about the development and usage of the Helium Blockchain Explorer takes place in the [official Helium Discord Server](https://discord.gg/helium), specifically in the `#explorer-dev` channel. Join us!
 - For a list of issues and prioritization, please go to our [Project page](https://github.com/orgs/helium/projects/9).
 


### PR DESCRIPTION
Hello,

For quick testing and don't have to install npm/yarn, we can now use Docker to run  helium-explorer dev environment.