### PR TITLE
fixed x/page problem in HotspotsList, WitnessesList

### DIFF
--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Table, Card } from 'antd'
 import { Content } from './AppLayout'
 import Link from 'next/link'
@@ -86,6 +86,11 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
     },
   ]
 
+  const [pageSize, setPageSize] = useState(5)
+  const handleTableChange = (pagination, filter, sorter) => {
+    setPageSize(pagination.pageSize)
+  }
+
   return (
     <Content style={{ marginBottom: 20 }}>
       <Card loading={hotspotsLoading} title={'Hotspots'}>
@@ -108,8 +113,9 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
             loading={hotspotsLoading}
             size="small"
             rowKey="name"
-            pagination={{ pageSize: 10, hideOnSinglePage: true }}
+            pagination={{ pageSize }}
             scroll={{ x: true }}
+            onChange={handleTableChange}
           />
         )}
       </Card>

--- a/components/HotspotsList.js
+++ b/components/HotspotsList.js
@@ -86,14 +86,18 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
     },
   ]
 
-  const [pageSize, setPageSize] = useState(5)
+  const PAGE_SIZE_DEFAULT = 10
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
   const handleTableChange = (pagination, filter, sorter) => {
     setPageSize(pagination.pageSize)
   }
 
   return (
     <Content style={{ marginBottom: 20 }}>
-      <Card loading={hotspotsLoading} title={'Hotspots'}>
+      <Card
+        loading={hotspotsLoading}
+        title={`Hotspots${!hotspotsLoading ? ` (${hotspots.length})` : ''}`}
+      >
         {hotspots.length == 0 ? (
           <h2
             style={{
@@ -107,16 +111,23 @@ const HotspotsList = ({ hotspots, rewardsLoading, hotspotsLoading }) => {
             Account has no hotspots
           </h2>
         ) : (
-          <Table
-            dataSource={hotspots}
-            columns={hotspotColumns}
-            loading={hotspotsLoading}
-            size="small"
-            rowKey="name"
-            pagination={{ pageSize }}
-            scroll={{ x: true }}
-            onChange={handleTableChange}
-          />
+          <span className="ant-table-styling-override">
+            <Table
+              dataSource={hotspots}
+              columns={hotspotColumns}
+              loading={hotspotsLoading}
+              size="small"
+              rowKey="name"
+              pagination={{
+                pageSize,
+                showSizeChanger: hotspots.length > PAGE_SIZE_DEFAULT,
+                hideOnSinglePage: hotspots.length <= PAGE_SIZE_DEFAULT,
+                pageSizeOptions: [5, 10, 20, 50, 100],
+              }}
+              scroll={{ x: true }}
+              onChange={handleTableChange}
+            />
+          </span>
         )}
       </Card>
     </Content>

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -41,23 +41,35 @@ const columns = [
 ]
 
 const NearbyHotspotsList = ({ nearbyHotspots, nearbyHotspotsLoading }) => {
-  const [pageSize, setPageSize] = useState(5)
+  const PAGE_SIZE_DEFAULT = 5
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
 
   const handleTableChange = (pagination, filter, sorter) => {
     setPageSize(pagination.pageSize)
   }
   return (
-    <Card title={'Nearby Hotspots'}>
-      <Table
-        dataSource={nearbyHotspots}
-        columns={columns}
-        size="small"
-        loading={nearbyHotspotsLoading}
-        rowKey="name"
-        pagination={{ pageSize }}
-        scroll={{ x: true }}
-        onChange={handleTableChange}
-      />
+    <Card
+      title={`Nearby Hotspots${
+        !nearbyHotspotsLoading ? ` (${nearbyHotspots.length})` : ''
+      }`}
+    >
+      <span className="ant-table-styling-override">
+        <Table
+          dataSource={nearbyHotspots}
+          columns={columns}
+          size="small"
+          loading={nearbyHotspotsLoading}
+          rowKey="name"
+          pagination={{
+            pageSize,
+            showSizeChanger: nearbyHotspots.length > PAGE_SIZE_DEFAULT,
+            hideOnSinglePage: nearbyHotspots.length <= PAGE_SIZE_DEFAULT,
+            pageSizeOptions: [5, 10, 20, 50, 100],
+          }}
+          scroll={{ x: true }}
+          onChange={handleTableChange}
+        />
+      </span>
     </Card>
   )
 }

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Card, Table } from 'antd'
 import Link from 'next/link'
 import { StatusCircle } from './Hotspots'
@@ -40,18 +40,26 @@ const columns = [
   },
 ]
 
-const NearbyHotspotsList = ({ nearbyHotspots, nearbyHotspotsLoading }) => (
-  <Card title={'Nearby Hotspots'}>
-    <Table
-      dataSource={nearbyHotspots}
-      columns={columns}
-      size="small"
-      loading={nearbyHotspotsLoading}
-      rowKey="name"
-      pagination={{ pageSize: 5, hideOnSinglePage: true }}
-      scroll={{ x: true }}
-    />
-  </Card>
-)
+const NearbyHotspotsList = ({ nearbyHotspots, nearbyHotspotsLoading }) => {
+  const [pageSize, setPageSize] = useState(5)
+
+  const handleTableChange = (pagination, filter, sorter) => {
+    setPageSize(pagination.pageSize)
+  }
+  return (
+    <Card title={'Nearby Hotspots'}>
+      <Table
+        dataSource={nearbyHotspots}
+        columns={columns}
+        size="small"
+        loading={nearbyHotspotsLoading}
+        rowKey="name"
+        pagination={{ pageSize }}
+        scroll={{ x: true }}
+        onChange={handleTableChange}
+      />
+    </Card>
+  )
+}
 
 export default NearbyHotspotsList

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -57,7 +57,8 @@ const columns = [
 ]
 
 const WitnessesList = ({ witnesses, witnessesLoading }) => {
-  const [pageSize, setPageSize] = useState(5)
+  const PAGE_SIZE_DEFAULT = 5
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
 
   const handleTableChange = (pagination, filter, sorter) => {
     setPageSize(pagination.pageSize)
@@ -73,7 +74,7 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => {
             justifyContent: 'flex-start',
           }}
         >
-          Recent Witnesses
+          Recent Witnesses{!witnessesLoading ? ` (${witnesses.length})` : ''}
           <Tooltip placement="top" title={'Witnesses from the last 5 days'}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -98,16 +99,23 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => {
         </span>
       }
     >
-      <Table
-        dataSource={witnesses}
-        columns={columns}
-        size="small"
-        loading={witnessesLoading}
-        rowKey="name"
-        pagination={{ pageSize }}
-        scroll={{ x: true }}
-        onChange={handleTableChange}
-      />
+      <span className="ant-table-styling-override">
+        <Table
+          dataSource={witnesses}
+          columns={columns}
+          size="small"
+          loading={witnessesLoading}
+          rowKey="name"
+          pagination={{
+            pageSize,
+            showSizeChanger: witnesses.length > PAGE_SIZE_DEFAULT,
+            hideOnSinglePage: witnesses.length <= PAGE_SIZE_DEFAULT,
+            pageSizeOptions: [5, 10, 20, 50, 100],
+          }}
+          scroll={{ x: true }}
+          onChange={handleTableChange}
+        />
+      </span>
     </Card>
   )
 }

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Card, Table, Tooltip } from 'antd'
 import Link from 'next/link'
 import { formatHotspotName, formatLocation } from './Hotspots/utils'
@@ -56,51 +56,60 @@ const columns = [
   },
 ]
 
-const WitnessesList = ({ witnesses, witnessesLoading }) => (
-  <Card
-    title={
-      <span
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'flex-start',
-        }}
-      >
-        Recent Witnesses
-        <Tooltip placement="top" title={'Witnesses from the last 5 days'}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            style={{
-              color: '#999',
-              height: 18,
-              width: 18,
-              marginLeft: 10,
-            }}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-        </Tooltip>
-      </span>
-    }
-  >
-    <Table
-      dataSource={witnesses}
-      columns={columns}
-      size="small"
-      loading={witnessesLoading}
-      rowKey="name"
-      pagination={{ pageSize: 5, hideOnSinglePage: true }}
-      scroll={{ x: true }}
-    />
-  </Card>
-)
+const WitnessesList = ({ witnesses, witnessesLoading }) => {
+  const [pageSize, setPageSize] = useState(5)
+
+  const handleTableChange = (pagination, filter, sorter) => {
+    setPageSize(pagination.pageSize)
+  }
+
+  return (
+    <Card
+      title={
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+          }}
+        >
+          Recent Witnesses
+          <Tooltip placement="top" title={'Witnesses from the last 5 days'}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              style={{
+                color: '#999',
+                height: 18,
+                width: 18,
+                marginLeft: 10,
+              }}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </Tooltip>
+        </span>
+      }
+    >
+      <Table
+        dataSource={witnesses}
+        columns={columns}
+        size="small"
+        loading={witnessesLoading}
+        rowKey="name"
+        pagination={{ pageSize }}
+        scroll={{ x: true }}
+        onChange={handleTableChange}
+      />
+    </Card>
+  )
+}
 
 export default WitnessesList

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -451,6 +451,10 @@ hr {
   margin: 0 !important;
 }
 
+.ant-table-styling-override .ant-pagination-options {
+  margin-right: 20px;
+}
+
 @media screen and (max-width: 1200px) {
   .map-button {
     min-width: 0;


### PR DESCRIPTION
Fixes issue - #191 

Fixed x/page problem in:- 

1. Recent witnesses list on hotspot page
2. Nearby hotspots list on hotspot page
3. Hotpots list on the account page

@danielcolinjames, the 5/page option is set to default in the state initially and works absolutely fine but after changing to other options, it gets disappeared from the list. I couldn't figure out why this is happening, I would love to know your suggestion on this.

Pardon me for the low-quality screen capture. 😅 

![helim-table-pagination-fix](https://user-images.githubusercontent.com/42844688/107755189-81577f00-6d48-11eb-8941-b7fbe2a61461.gif)

