### PR TITLE
Make CSV decimal separator respect locale

### DIFF
--- a/components/ExportCSV/ExportModal.js
+++ b/components/ExportCSV/ExportModal.js
@@ -101,7 +101,7 @@ class ExportModal extends React.Component {
       filename: `${type === 'account' ? 'Account' : 'Hotspot'} ${address}`,
       fieldSeparator: ',',
       quoteStrings: '"',
-      decimalSeparator: '.',
+      decimalSeparator: 'locale',
       showLabels: true,
       useTextFile: false,
       useBom: true,


### PR DESCRIPTION
This might solve an issue where users with non-US/English language settings on their computer or browser may have a hard time getting the CSV to import properly into various spreadsheet software because it was expecting a `,` as the decimal separator and getting a `.`