### PR TITLE
Add a checkbox to hide offline hotspots

### DIFF
--- a/components/CoverageMap/CoverageMap.js
+++ b/components/CoverageMap/CoverageMap.js
@@ -288,7 +288,7 @@ class CoverageMap extends React.Component {
   }
 
   renderOverviewMap = () => {
-    const { selectedHotspots } = this.props
+    const { selectedHotspots, showOffline } = this.props
     const { online, offline } = this.state
 
     const selectedData = geoJSON.parse(selectedHotspots[0] || [], {
@@ -352,7 +352,7 @@ class CoverageMap extends React.Component {
 
         <GeoJSONLayer
           id="offline-hotspots"
-          data={offline || emptyGeoJSON}
+          data={(showOffline && offline) || emptyGeoJSON}
           circlePaint={offlineCircleLayout}
           circleOnClick={this.handleHotspotClick}
         />

--- a/components/CoverageMap/HotspotSidebar.js
+++ b/components/CoverageMap/HotspotSidebar.js
@@ -88,13 +88,15 @@ const HotspotSidebar = ({
             </span>
             <span className="header-subtitle mono">{titleText}</span>
           </div>
-          <Checkbox
-            onChange={updateShowOffline}
-            checked={showOffline}
-            style={{ color: 'white', marginTop: '10px' }}
-          >
-            Show offline hotspots
-          </Checkbox>
+          <span className="ant-checkbox-override">
+            <Checkbox
+              onChange={updateShowOffline}
+              checked={showOffline}
+              style={{ color: '#aaa', marginLeft: '5px', marginTop: '14px' }}
+            >
+              Show offline hotspots
+            </Checkbox>
+          </span>
         </SidebarHeader>
 
         <SidebarScrollable loadMore={fetchMoreHotspots}>

--- a/components/CoverageMap/HotspotSidebar.js
+++ b/components/CoverageMap/HotspotSidebar.js
@@ -1,193 +1,199 @@
-import React, { Component } from 'react'
+import React from 'react'
 import Sidebar, { SidebarHeader, SidebarScrollable } from './Sidebar'
 import Hotspot from './Hotspot'
 import Link from 'next/link'
 import withSearchResults from '../SearchBar/withSearchResults'
+import { Checkbox } from 'antd'
 
 const hotspotToObj = (hotspot) => ({
   ...hotspot,
   location: hotspot.geocode.longCity + ', ' + hotspot.geocode.shortState,
 })
 
-class HotspotSidebar extends Component {
-  updateFilter = (e) => {
-    this.props.updateSearchTerm(e.target.value)
+const HotspotSidebar = ({
+  hotspots,
+  count,
+  selectedHotspots,
+  selectHotspots,
+  clearSelectedHotspots,
+  fetchMoreHotspots,
+  searchResults,
+  searchTerm,
+  showOffline,
+  setShowOffline,
+  ...props
+}) => {
+  const updateFilter = (e) => {
+    props.updateSearchTerm(e.target.value)
+  }
+  const updateShowOffline = (e) => {
+    setShowOffline(e.target.checked)
   }
 
-  render() {
-    const {
-      hotspots,
-      count,
-      selectedHotspots,
-      selectHotspots,
-      clearSelectedHotspots,
-      fetchMoreHotspots,
-      searchResults,
-      searchTerm,
-    } = this.props
+  let hotspotsToShow = hotspots
+  if (selectedHotspots.length > 0) {
+    hotspotsToShow = selectedHotspots
+  } else if (searchTerm !== '') {
+    hotspotsToShow = (
+      searchResults.find((r) => r.category === 'Hotspots')?.results || []
+    ).map(hotspotToObj)
+  }
 
-    let hotspotsToShow = hotspots
-    if (selectedHotspots.length > 0) {
-      hotspotsToShow = selectedHotspots
-    } else if (searchTerm !== '') {
-      hotspotsToShow = (
-        searchResults.find((r) => r.category === 'Hotspots')?.results || []
-      ).map(hotspotToObj)
+  let titleText = 'Hotspots'
+  if (selectedHotspots.length > 0) {
+    if (selectedHotspots.length > 1) {
+      titleText = 'Hotspots Selected'
+    } else {
+      titleText = 'Hotspot Selected'
     }
+  }
 
-    let titleText = 'Hotspots'
-    if (selectedHotspots.length > 0) {
-      if (selectedHotspots.length > 1) {
-        titleText = 'Hotspots Selected'
-      } else {
-        titleText = 'Hotspot Selected'
-      }
-    }
-
-    return (
-      <span className="coverage-map-sidebar">
-        <Sidebar>
-          <SidebarHeader>
-            {selectedHotspots.length > 0 ? (
-              <div className="header-search">
-                <span
-                  className="header-go-back"
-                  onClick={clearSelectedHotspots}
-                >
-                  <img src="/images/back.svg" className="header-back-img" />{' '}
-                  Back
-                </span>
-                {selectedHotspots.length === 1 && (
-                  <>
-                    <Link href={`/hotspots/${selectedHotspots[0].address}`}>
-                      <a target="_blank" className="header-view-details">
-                        View Hotspot Details
-                        <img
-                          src="/images/back.svg"
-                          className="header-fwd-img"
-                        />{' '}
-                      </a>
-                    </Link>
-                  </>
-                )}
-              </div>
-            ) : (
-              <div className="header-search">
-                <input
-                  type="search"
-                  className="search"
-                  placeholder="Hotspot Lookup"
-                  value={searchTerm}
-                  onChange={this.updateFilter}
-                />
-              </div>
-            )}
-            <div className="header-title-section">
-              <span className="header-title mono">
-                {selectedHotspots.length > 0 ? hotspotsToShow.length : count}
+  return (
+    <span className="coverage-map-sidebar">
+      <Sidebar>
+        <SidebarHeader>
+          {selectedHotspots.length > 0 ? (
+            <div className="header-search">
+              <span className="header-go-back" onClick={clearSelectedHotspots}>
+                <img src="/images/back.svg" className="header-back-img" /> Back
               </span>
-              <span className="header-subtitle mono">{titleText}</span>
+              {selectedHotspots.length === 1 && (
+                <>
+                  <Link href={`/hotspots/${selectedHotspots[0].address}`}>
+                    <a target="_blank" className="header-view-details">
+                      View Hotspot Details
+                      <img
+                        src="/images/back.svg"
+                        className="header-fwd-img"
+                      />{' '}
+                    </a>
+                  </Link>
+                </>
+              )}
             </div>
-          </SidebarHeader>
+          ) : (
+            <div className="header-search">
+              <input
+                type="search"
+                className="search"
+                placeholder="Hotspot Lookup"
+                value={searchTerm}
+                onChange={updateFilter}
+              />
+            </div>
+          )}
+          <div className="header-title-section">
+            <span className="header-title mono">
+              {selectedHotspots.length > 0 ? hotspotsToShow.length : count}
+            </span>
+            <span className="header-subtitle mono">{titleText}</span>
+          </div>
+          <Checkbox
+            onChange={updateShowOffline}
+            checked={showOffline}
+            style={{ color: 'white', marginTop: '10px' }}
+          >
+            Show offline hotspots
+          </Checkbox>
+        </SidebarHeader>
 
-          <SidebarScrollable loadMore={fetchMoreHotspots}>
-            {hotspotsToShow.map((hotspot) => (
-              <div key={hotspot.address}>
-                <Hotspot
-                  key={hotspot.address}
-                  hotspot={hotspot}
-                  selectHotspots={selectHotspots}
-                />
-              </div>
-            ))}
-          </SidebarScrollable>
-        </Sidebar>
-        <style jsx>{`
-          .header-search {
-            margin-bottom: 20px;
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            justify-content: space-between;
-          }
+        <SidebarScrollable loadMore={fetchMoreHotspots}>
+          {hotspotsToShow.map((hotspot) => (
+            <div key={hotspot.address}>
+              <Hotspot
+                key={hotspot.address}
+                hotspot={hotspot}
+                selectHotspots={selectHotspots}
+              />
+            </div>
+          ))}
+        </SidebarScrollable>
+      </Sidebar>
+      <style jsx>{`
+        .header-search {
+          margin-bottom: 20px;
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          justify-content: space-between;
+        }
 
+        .search {
+          background: #263441;
+          width: 100%;
+          padding: 8px 10px;
+          font-size: 12px;
+          color: #a0b0c2;
+          -webkit-appearance: none;
+          border-radius: 6px;
+          border: none;
+        }
+
+        @media screen and (max-width: 890px) {
           .search {
-            background: #263441;
-            width: 100%;
-            padding: 8px 10px;
-            font-size: 12px;
-            color: #a0b0c2;
-            -webkit-appearance: none;
-            border-radius: 6px;
-            border: none;
-          }
-
-          @media screen and (max-width: 890px) {
-            .search {
-              font-size: 16px;
-              /* So that pressing on the input field on a phone doesn't cause the UI to zoom in slightly */
-            }
-          }
-
-          .search::placeholder {
-            color: #a0b0c2;
-            opacity: 1;
-          }
-
-          .header-title-section {
-            display: flex;
-            align-items: flex-end;
-            padding-top: 10px;
-          }
-
-          .header-title {
-            color: #29d391;
-            font-size: 60px;
-            font-weight: 500;
-            margin-right: 10px;
-            line-height: 48px;
-          }
-
-          .header-subtitle {
-            color: #a0b0c2;
             font-size: 16px;
-            font-weight: 500;
-            max-width: 200px;
-            line-height: normal;
+            /* So that pressing on the input field on a phone doesn't cause the UI to zoom in slightly */
           }
+        }
 
-          .header-go-back {
-            color: #a0b0c2;
-            font-size: 16px;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            width: 75px;
-            padding: 6px 0;
-          }
+        .search::placeholder {
+          color: #a0b0c2;
+          opacity: 1;
+        }
 
-          .header-view-details {
-            color: #a0b0c2;
-            font-size: 16px;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            padding: 6px 0;
-          }
+        .header-title-section {
+          display: flex;
+          align-items: flex-end;
+          padding-top: 10px;
+        }
 
-          .header-back-img {
-            height: 10px;
-            margin-right: 6px;
-          }
-          .header-fwd-img {
-            height: 10px;
-            margin-left: 6px;
-            transform: rotate(180deg);
-          }
-        `}</style>
-      </span>
-    )
-  }
+        .header-title {
+          color: #29d391;
+          font-size: 60px;
+          font-weight: 500;
+          margin-right: 10px;
+          line-height: 48px;
+        }
+
+        .header-subtitle {
+          color: #a0b0c2;
+          font-size: 16px;
+          font-weight: 500;
+          max-width: 200px;
+          line-height: normal;
+        }
+
+        .header-go-back {
+          color: #a0b0c2;
+          font-size: 16px;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          width: 75px;
+          padding: 6px 0;
+        }
+
+        .header-view-details {
+          color: #a0b0c2;
+          font-size: 16px;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          padding: 6px 0;
+        }
+
+        .header-back-img {
+          height: 10px;
+          margin-right: 6px;
+        }
+        .header-fwd-img {
+          height: 10px;
+          margin-left: 6px;
+          transform: rotate(180deg);
+        }
+      `}</style>
+    </span>
+  )
 }
 
 export default withSearchResults(HotspotSidebar)

--- a/pages/coverage.js
+++ b/pages/coverage.js
@@ -22,6 +22,7 @@ const Coverage = (props) => {
   const [hotspotList, setHotspotList] = useState(null)
   const [hotspots, setHotspots] = useState([])
   const [selectedHotspots, setSelectedHotspots] = useState([])
+  const [showOffline, setShowOffline] = useState(true)
 
   useEffect(() => {
     const setupHotspotList = async () => {
@@ -72,11 +73,14 @@ const Coverage = (props) => {
         selectHotspots={selectHotspots}
         clearSelectedHotspots={clearSelectedHotspots}
         fetchMoreHotspots={fetchMoreHotspots}
+        setShowOffline={setShowOffline}
+        showOffline={showOffline}
       />
       <Map
         selectedHotspots={selectedHotspots}
         selectHotspots={selectHotspots}
         clearSelectedHotspots={clearSelectedHotspots}
+        showOffline={showOffline}
       />
     </Page>
   )

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -485,6 +485,14 @@ hr {
   padding: 0 0 0 24px;
 }
 
+.ant-checkbox-override .ant-checkbox-checked .ant-checkbox-inner {
+  background-color: #1e5b50;
+  border-color: #1e5b50;
+}
+.ant-checkbox-override .ant-checkbox-checked::after {
+  border: 1px solid #29d391;
+}
+
 @media screen and (max-width: 1200px) {
   .map-button {
     min-width: 0;


### PR DESCRIPTION
There are two more things to do:

1) Check the styling: I tried with the `mono` class and the header font color (`#a0b0c2`) but didn't really like it. Of course, I can still change to your preference.

2) Update the hotspot count: right now, the hotspot count by default includes all hotspots, even the ones that don't have a location set. Should I default to `online.length + offline.length` instead? If so, I probably can't get that data before `/api/coverage` finishes loading. That information also is not available in `stats.count`, and it would be weird to update it once the API call finished. At this point I haven't updated the count at all.

I can also keep the React `Component` stuff instead of updating it to a function in this PR in order to keep a simple PR.