### PR TITLE
Deduplicate the generateCoverage script

### DIFF
--- a/jobs/generate_coverage.js
+++ b/jobs/generate_coverage.js
@@ -1,6 +1,5 @@
-const { Client } = require('@helium/http')
-const geoJSON = require('geojson')
 const Redis = require('ioredis')
+const { getCoverage } = require('../pages/api/coverage')
 
 const redisClient = new Redis(process.env.REDIS_URL)
 
@@ -9,19 +8,7 @@ const setCache = async (key, value) => {
 }
 
 const generateCoverage = async () => {
-  const client = new Client()
-  const allHotspots = await (await client.hotspots.list()).takeJSON(100000)
-  const hotspots = allHotspots.map((h) => ({
-    ...h,
-    location: [h.geocode.longCity, h.geocode.shortState].join(', '),
-  }))
-
-  const coverage = geoJSON.parse(hotspots, {
-    Point: ['lat', 'lng'],
-    include: ['address', 'owner', 'location'],
-  })
-
-  await setCache('coverage', coverage)
+  await setCache('coverage', await getCoverage())
 
   return process.exit(0)
 }

--- a/pages/api/coverage.js
+++ b/pages/api/coverage.js
@@ -28,7 +28,7 @@ const toGeoJSON = (hotspots) =>
     include: ['address', 'owner', 'location', 'status'],
   })
 
-const getCoverage = async () => {
+export const getCoverage = async () => {
   const client = new Client()
   const hotspots = await client.hotspots.list()
   const result = {


### PR DESCRIPTION
This directly uses the `getCoverage` function instead of duplicating the code, and should thus be more future proof.