### PR TITLE
Fix the generate_coverage.js script

### DIFF
--- a/commonjs/coverage.js
+++ b/commonjs/coverage.js
@@ -1,0 +1,44 @@
+const { Client } = require('@helium/http')
+const geoJSON = require('geojson')
+
+const toGeoJSON = (hotspots) =>
+  geoJSON.parse(hotspots, {
+    Point: ['lat', 'lng'],
+    include: ['address', 'owner', 'location', 'status'],
+  })
+
+const getCoverage = async () => {
+  const client = new Client()
+  const hotspots = await client.hotspots.list()
+  const result = {
+    unset: 0,
+    online: [],
+    offline: [],
+  }
+
+  for await (const { data } of hotspots) {
+    const hotspot = {
+      ...data,
+      location: [data.geocode.longCity, data.geocode.shortState]
+        .filter(Boolean)
+        .join(', '),
+      status: data.status.online,
+    }
+
+    if (!hotspot.lng || !hotspot.lat) {
+      result.unset++
+      continue
+    }
+
+    const isOnline = hotspot.status === 'online'
+    result[isOnline ? 'online' : 'offline'].push(hotspot)
+  }
+
+  return {
+    ...result,
+    online: toGeoJSON(result.online),
+    offline: toGeoJSON(result.offline),
+  }
+}
+
+module.exports = { getCoverage }

--- a/jobs/generate_coverage.js
+++ b/jobs/generate_coverage.js
@@ -1,5 +1,5 @@
 const Redis = require('ioredis')
-const { getCoverage } = require('../pages/api/coverage')
+const { getCoverage } = require('../commonjs/coverage.js')
 
 const redisClient = new Redis(process.env.REDIS_URL)
 

--- a/jobs/generate_coverage.js
+++ b/jobs/generate_coverage.js
@@ -1,5 +1,5 @@
 const Redis = require('ioredis')
-const { getCoverage } = require('../commonjs/coverage.js')
+const { getCoverage } = require('../commonjs/coverage')
 
 const redisClient = new Redis(process.env.REDIS_URL)
 


### PR DESCRIPTION
So, I think (but it's hard to say without logs of Heroku's scheduler), that the issue was that `generate_coverage.js` is a CommonJS script ran directly by `node`. Thus, it doesn't understand ES Modules, and the `export const getCoverage` I added in #230 didn't make sense.

This fix moves `getCoverage` to a `commonjs` folder, and makes use of `require` in that "library" file. This file can be imported by both CommonJS (`jobs/generate_coverage.js`) and ES Modules (`api/coverage.js`). This can be tested by running:

```
$ REDIS_URL=redis://localhost/ node jobs/generate_coverage.js
```

and then checking if the following command returns something:

```
$ redis-cli get coverage
```

If so, navigating to `http://localhost:3000/api/coverage` should return a response fairly quickly if the API was ran like so:

```
$ REDIS_URL=redis://localhost/ yarn dev
```