### PR TITLE
use wallet-api for nearby hotspots query

### DIFF
--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -76,7 +76,7 @@ const HotspotMapbox = ({
 
   // include nearby hotspots in centering / zooming logic
   nearbyHotspots.map((h) => {
-    boundsLocations.push({ lng: h?._geoloc.lng, lat: h?._geoloc.lat })
+    boundsLocations.push({ lng: h?.lng, lat: h?.lat })
   })
 
   // calculate map bounds

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -32,11 +32,9 @@ const columns = [
   },
   {
     title: 'Distance',
-    dataIndex: '_rankingInfo',
-    key: 'distance',
-    render: ({ geoDistance: distance }) => (
-      <span>{formatDistance(distance)}</span>
-    ),
+    dataIndex: 'dist',
+    key: 'dist',
+    render: (dist) => <span>{formatDistance(dist)}</span>,
   },
 ]
 

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -51,23 +51,37 @@ const NearbyHotspotsList = ({ nearbyHotspots, nearbyHotspotsLoading }) => {
         !nearbyHotspotsLoading ? ` (${nearbyHotspots.length})` : ''
       }`}
     >
-      <span className="ant-table-styling-override">
-        <Table
-          dataSource={nearbyHotspots}
-          columns={columns}
-          size="small"
-          loading={nearbyHotspotsLoading}
-          rowKey="name"
-          pagination={{
-            pageSize,
-            showSizeChanger: nearbyHotspots.length > PAGE_SIZE_DEFAULT,
-            hideOnSinglePage: nearbyHotspots.length <= PAGE_SIZE_DEFAULT,
-            pageSizeOptions: [5, 10, 20, 50, 100],
+      {nearbyHotspots.length === 0 ? (
+        <p
+          style={{
+            textAlign: 'center',
+            marginTop: '0.5rem',
+            fontSize: '14px',
+            color: 'rgba(0, 0, 0, 0.25)',
+            padding: '20px',
           }}
-          scroll={{ x: true }}
-          onChange={handleTableChange}
-        />
-      </span>
+        >
+          Hotspot has no nearby hotspots (within 2km)
+        </p>
+      ) : (
+        <span className="ant-table-styling-override">
+          <Table
+            dataSource={nearbyHotspots}
+            columns={columns}
+            size="small"
+            loading={nearbyHotspotsLoading}
+            rowKey="name"
+            pagination={{
+              pageSize,
+              showSizeChanger: nearbyHotspots.length > PAGE_SIZE_DEFAULT,
+              hideOnSinglePage: nearbyHotspots.length <= PAGE_SIZE_DEFAULT,
+              pageSizeOptions: [5, 10, 20, 50, 100],
+            }}
+            scroll={{ x: true }}
+            onChange={handleTableChange}
+          />
+        </span>
+      )}
     </Card>
   )
 }

--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import Client from '@helium/http'
+import qs from 'qs'
 
 export const fetchLatestHotspots = async (count = 20) => {
   const client = new Client()
@@ -43,4 +44,13 @@ export const getHotspotRewardsBuckets = async (
   })
   const rewards = await list.take(MAX)
   return rewards
+}
+
+export const fetchNearbyHotspots = async (lat, lng, dist = 1000) => {
+  if (!lat || !lng) return []
+  const params = qs.stringify({ lat, lng, dist })
+  const url = 'https://wallet.api.helium.systems/api/v1/hotspots?' + params
+  const response = await fetch(url)
+  const hotspots = await response.json()
+  return hotspots
 }

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -21,9 +21,8 @@ import {
 import sumBy from 'lodash/sumBy'
 
 import {
-  fetchRewardsSummary,
+  fetchNearbyHotspots,
   getHotspotRewardsBuckets,
-  getHotspotRewardsSum,
 } from '../../data/hotspots'
 import Hex from '../../components/Hex'
 import { generateRewardScaleColor } from '../../components/Hotspots/utils'
@@ -82,20 +81,8 @@ const HotspotView = ({ hotspot }) => {
     }
     async function getNearbyHotspots() {
       setNearbyHotspotsLoading(true)
-      const algoliaClient = algoliasearch(
-        process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-        process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
-      )
-      const hotspotsIndex = algoliaClient.initIndex('hotspots')
-      const { hits: nearbyHotspotsResults } = await hotspotsIndex.search('', {
-        aroundLatLng: [
-          hotspot.lat ? hotspot.lat : 0,
-          hotspot.lng ? hotspot.lng : 0,
-        ].join(', '),
-        getRankingInfo: true,
-        filters: `NOT address:${hotspotid}`,
-      })
-      setNearbyHotspots(nearbyHotspotsResults)
+      const hotspots = await fetchNearbyHotspots(hotspot.lat, hotspot.lng, 2000)
+      setNearbyHotspots(hotspots.filter((h) => h.address !== hotspotid))
       setNearbyHotspotsLoading(false)
     }
 

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Row, Typography, Checkbox, Tooltip } from 'antd'
 import Client from '@helium/http'
-import algoliasearch from 'algoliasearch'
 import Fade from 'react-reveal/Fade'
 import Checklist from '../../components/Hotspots/Checklist/Checklist'
 import RewardSummary from '../../components/Hotspots/RewardSummary'


### PR DESCRIPTION
wallet-api now exposes a nearby hotspots API that we're using in the app. Eventually we expect the blockchain API to expose this as well (see https://github.com/helium/blockchain-http/issues/187). But because the app needed it sooner, I implemented postgis in wallet-api to hold us over. I'd like to use it here because 1) algolia is getting $$$ and this will reduce a number of calls we make to it 2) it allows for more flexible distance querying (with algolia we specify a limit to the number of search results, with wallet-api we specify a distance and everything within that radius is returned)