### PR TITLE
Nearby hotspot fixes

### DIFF
--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -76,7 +76,7 @@ const HotspotMapbox = ({
 
   // include nearby hotspots in centering / zooming logic
   nearbyHotspots.map((h) => {
-    boundsLocations.push({ lng: h?.lng, lat: h?.lat })
+    boundsLocations.push({ lng: parseFloat(h?.lng), lat: parseFloat(h?.lat) })
   })
 
   // calculate map bounds

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -15,7 +15,8 @@ const columns = [
     key: 'name',
     render: (name, row) => (
       <>
-        <StatusCircle status={row.status} />
+        {/* hiding status for now until status is something that comes back in nearby API response */}
+        {/* <StatusCircle status={row.status} /> */}
         <Link href={'/hotspots/' + row.address} prefetch={false}>
           <a style={{ fontFamily: "'Inter', sans-serif" }}>
             {formatHotspotName(name)}


### PR DESCRIPTION
Two fixes in this PR:

1. The "Nearby hotspots" table was showing all of them as offline because status isn't a field included anymore (this fixes #235)
2. Some pages were breaking when a "nearby" hotspot was used in the calculation for the map bounds, because the new method of getting nearby hotspots by distance returns lat/lng as a string instead of a number