### PR TITLE
Use getServerSideProps instead of getStaticProps for account page

### DIFF
--- a/pages/accounts/[accountid].js
+++ b/pages/accounts/[accountid].js
@@ -242,14 +242,7 @@ const AccountView = ({ account }) => {
   )
 }
 
-export async function getStaticPaths() {
-  return {
-    paths: [],
-    fallback: 'blocking',
-  }
-}
-
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
   const client = new Client()
   const { accountid } = params
   const account = await client.accounts.get(accountid)
@@ -258,7 +251,6 @@ export async function getStaticProps({ params }) {
     props: {
       account: JSON.parse(JSON.stringify(account)),
     },
-    revalidate: 10,
   }
 }
 


### PR DESCRIPTION
Small change, and should stop people seeing stale balances on their account pages for now. It'll still require a refresh of the page to refetch for now but at least won't show the "previous" balance any more. We can use swr to make it update on some interval on top of this, but for now this should at least be better than stale balances. And probably won't perform that differently than the existing fetch too because we're currently using `fallback: "blocking"` anyway with `getStaticProps`