### PR TITLE
Fix offline indicator color

### DIFF
--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -19,7 +19,7 @@ import {
 } from '../../components/Hotspots/utils'
 import sumBy from 'lodash/sumBy'
 import ReactCountryFlag from 'react-country-flag'
-
+import classNames from 'classnames'
 import {
   fetchNearbyHotspots,
   getHotspotRewardsBuckets,
@@ -209,11 +209,18 @@ const HotspotView = ({ hotspot }) => {
                         title={`Hotspot is ${hotspot.status.online}`}
                       >
                         <div
-                          className={`h-2.5 w-2.5 rounded-full ${
-                            hotspot.status.online
-                              ? 'bg-green-500'
-                              : 'bg-red-400'
-                          }`}
+                          className={classNames(
+                            'h-2.5',
+                            'w-2.5',
+                            'rounded-full',
+                            {
+                              'bg-green-500':
+                                hotspot.status.online === 'online',
+                            },
+                            {
+                              'bg-red-400': hotspot.status.online === 'offline',
+                            },
+                          )}
                         />
                       </Tooltip>
                       <Tooltip

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -216,8 +216,6 @@ const HotspotView = ({ hotspot }) => {
                             {
                               'bg-green-500':
                                 hotspot.status.online === 'online',
-                            },
-                            {
                               'bg-red-400': hotspot.status.online === 'offline',
                             },
                           )}


### PR DESCRIPTION
In #236 I accidentally messed up the conditional statement (checking for `hotspot.status.online` instead of `hotspot.status.online === 'online'`), so the indicator was showing up as green for offline hotspots. This PR uses the `classnames` package to fix it and also to make the conditional classes a little cleaner.

example: https://explorer.helium.com/hotspots/11LqnTThVZyKNxUWDqG1pLir8LCQLcBj8me4aStH1dSzYpqMynL
<img width="258" alt="Screen Shot 2021-03-05 at 2 54 01 PM" src="https://user-images.githubusercontent.com/10648471/110166797-dd02ae80-7dc2-11eb-9157-a9352747a5f6.png">
