### PR TITLE
Revert changes made to hide load more button

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -59,13 +59,12 @@ class ActivityList extends Component {
     this.setState({ loading: true })
     const { txns } = this.state
     const nextTxns = await this.list.take(20)
-    const nextPage = await this.list.nextPage()
 
     this.setState({
       txns: [...txns, ...nextTxns],
       loading: false,
       loadingInitial: false,
-      showLoadMoreButton: nextPage.hasMore,
+      showLoadMoreButton: nextTxns.hasMore,
     })
   }
 
@@ -180,7 +179,7 @@ class ActivityList extends Component {
               }}
             />
           )}
-          {showLoadMoreButton && <LoadMoreButton onClick={this.loadMore} />}
+          <LoadMoreButton onClick={this.loadMore} />
         </Card>
       </Content>
     )

--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -17,7 +17,7 @@ const initialState = {
   loading: true,
   loadingInitial: true,
   filtersOpen: false,
-  showLoadMoreButton: false,
+  showLoadMoreButton: true,
 }
 
 const exportableEntities = ['account', 'hotspot']
@@ -60,11 +60,14 @@ class ActivityList extends Component {
     const { txns } = this.state
     const nextTxns = await this.list.take(20)
 
+    if (nextTxns.length < 20) {
+      this.setState({ showLoadMoreButton: false })
+    }
+
     this.setState({
       txns: [...txns, ...nextTxns],
       loading: false,
       loadingInitial: false,
-      showLoadMoreButton: nextTxns.hasMore,
     })
   }
 
@@ -179,7 +182,7 @@ class ActivityList extends Component {
               }}
             />
           )}
-          <LoadMoreButton onClick={this.loadMore} />
+          {showLoadMoreButton && <LoadMoreButton onClick={this.loadMore} />}
         </Card>
       </Content>
     )


### PR DESCRIPTION
The fix in PR #240 seems to sometimes not display the Load More button when there should be more transactions to display. It seems like it might be hiding it when the _next page_ doesn't have any more, rather than when the current page doesn't have any more... But I'm not sure so that's just a guess.

I did a bit of playing with it to try and see if I could get it working more consistently but I need to spend a bit more time understanding helium-js and pagination to figure it out.

For now this PR just reverses the change made in that PR so the button will always be there even if there are no more transactions to load (re-opening issue #216), which isn't perfect either but at least is a bit better than hiding the button when there are actually more transactions to load.