### PR TITLE
Show beaconer reward scale instead of challenger's on beacon detail page

### DIFF
--- a/pages/beacons/[beaconid].js
+++ b/pages/beacons/[beaconid].js
@@ -20,7 +20,7 @@ const BeaconMap = dynamic(() => import('../../components/Beacons/BeaconMap'), {
   loading: () => <div className="h-80 md:h-96" />,
 })
 
-const Beacons = ({ beacon, challenger }) => {
+const Beacons = ({ beacon, challenger, challengee }) => {
   const totalWitnesses = sumBy(beacon?.path || [], 'witnesses.length')
   const paths = beacon?.path || []
 
@@ -99,11 +99,11 @@ const Beacons = ({ beacon, challenger }) => {
                         <FlagLocation geocode={path.geocode} />
                       </span>
                     </BeaconRow>
-                    {challenger.rewardScale && (
+                    {challengee.rewardScale && (
                       <div className="py-2 flex content-center">
                         <RewardScalePill
                           className="light-reward-pill flex content-center"
-                          hotspot={challenger}
+                          hotspot={challengee}
                         />
                         <div className="flex justify-center">
                           <AccountLink address={path.challengeeOwner} />
@@ -138,11 +138,12 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { beaconid } }) {
   const beacon = await fetchBeacon(beaconid)
   const challenger = await fetchHotspot(beacon.challenger)
-
+  const challengee = await fetchHotspot(beacon.path[0].challengee)
   return {
     props: {
       beacon,
       challenger,
+      challengee,
     },
   }
 }


### PR DESCRIPTION
NJ on Discord pointed out that the beacon detail page was showing a different reward scale than the one on the beaconer's hotspot page:
![Screen Shot 2021-03-19 at 7 42 01 PM](https://user-images.githubusercontent.com/10648471/111856919-4f0ee380-88eb-11eb-92f7-d252d46e1544.png)

After looking into it, that page was showing the challenger's reward scale instead of the beaconer's, so this PR fixes it to show the beaconer's instead