### PR TITLE
Hotspot page updates

### DIFF
--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -5,7 +5,7 @@ import { Pagination } from 'antd'
 import classNames from 'classnames'
 import { Checkbox } from 'antd'
 
-const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
+const CitiesTable = ({ topCities, topCitiesTotal }) => {
   const PAGE_SIZE_DEFAULT = 10
   const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
 
@@ -55,6 +55,47 @@ const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
     indexOfLast,
   )
 
+  const citiesColumns = [
+    {
+      title: 'Rank',
+      dataIndex: 'rank',
+      key: 'rank',
+      render: (data) => <span>{data}</span>,
+    },
+    {
+      title: '# Hotspots Deployed',
+      dataIndex: excludeOfflineHotspots ? 'online_count' : 'hotspot_count',
+      key: excludeOfflineHotspots ? 'online_count' : 'hotspot_count',
+      render: (data) => (
+        <span className="text-purple-700 font-semibold">{data}</span>
+      ),
+    },
+    {
+      title: 'City',
+      dataIndex: 'long_city',
+      key: 'long_city',
+      render: (data) => <span>{data}</span>,
+    },
+    {
+      title: 'Region',
+      dataIndex: 'long_state',
+      key: 'long_state',
+      render: (data) => <span>{data}</span>,
+    },
+    {
+      title: 'Country',
+      dataIndex: 'long_country',
+      key: 'long_country',
+      render: (data, row) => (
+        <div className="flex items-center justify-start">
+          <ReactCountryFlag countryCode={row.short_country} svg />
+          <div className="mr-2" />
+          <span className="m-0 p-0">{data}</span>
+        </div>
+      ),
+    },
+  ]
+
   return (
     <>
       <div className="hidden md:block">
@@ -77,8 +118,8 @@ const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
           pagination={{
             current: currentPage,
             pageSize,
-            showSizeChanger: cities.length > PAGE_SIZE_DEFAULT,
-            hideOnSinglePage: cities.length <= PAGE_SIZE_DEFAULT,
+            showSizeChanger: topCities.length > PAGE_SIZE_DEFAULT,
+            hideOnSinglePage: topCities.length <= PAGE_SIZE_DEFAULT,
             pageSizeOptions: [5, 10, 20, 50, 100],
             position: ['bottomCenter'],
           }}
@@ -125,17 +166,20 @@ const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
                 <div className="pl-14">
                   <div className="px-3 py-2">
                     <div className="flex items-center justify-start">
-                      <ReactCountryFlag countryCode={c.shortCountry} svg />
+                      <ReactCountryFlag countryCode={c.short_country} svg />
                       <span className="mr-2" />
                       <p className="text-black text-md font-semibold m-0 p-0">
-                        {c.longCity}
+                        {c.long_city}
                         <span className="m-0 p-0 font-normal text-gray-600">
-                          , {c.longCountry}
+                          , {c.long_country}
                         </span>
                       </p>
                     </div>
                     <p className="text-purple-700 font-semibold text-md m-0 p-0">
-                      {c.hotspotCount?.toLocaleString()} hotspots
+                      {excludeOfflineHotspots
+                        ? c.online_count?.toLocaleString()
+                        : c.hotspot_count?.toLocaleString()}{' '}
+                      hotspots
                     </p>
                   </div>
                 </div>
@@ -160,46 +204,5 @@ const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
     </>
   )
 }
-
-const citiesColumns = [
-  {
-    title: 'Rank',
-    dataIndex: 'rank',
-    key: 'rank',
-    render: (data) => <span>{data}</span>,
-  },
-  {
-    title: '# Hotspots Deployed',
-    dataIndex: 'hotspotCount',
-    key: 'hotspotCount',
-    render: (data) => (
-      <span className="text-purple-700 font-semibold">{data}</span>
-    ),
-  },
-  {
-    title: 'City',
-    dataIndex: 'longCity',
-    key: 'longCity',
-    render: (data) => <span>{data}</span>,
-  },
-  {
-    title: 'Region',
-    dataIndex: 'longState',
-    key: 'longState',
-    render: (data) => <span>{data}</span>,
-  },
-  {
-    title: 'Country',
-    dataIndex: 'longCountry',
-    key: 'longCountry',
-    render: (data, row) => (
-      <div className="flex items-center justify-start">
-        <ReactCountryFlag countryCode={row.shortCountry} svg />
-        <div className="mr-2" />
-        <span className="m-0 p-0">{data}</span>
-      </div>
-    ),
-  },
-]
 
 export default CitiesTable

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -53,7 +53,6 @@ const CitiesTable = ({ cities }) => {
           {currentPageOfCities.map((c, i, { length }) => {
             return (
               <div
-                // TODO: clean up styles using classnames package
                 className={classNames(
                   'relative flex flex-col border-t border-0 border-l border-r border-solid border-gray-500',
                   {

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -4,7 +4,7 @@ import ReactCountryFlag from 'react-country-flag'
 import { Pagination } from 'antd'
 import classNames from 'classnames'
 
-const CitiesTable = ({ cities, topCities }) => {
+const CitiesTable = ({ cities, topCities, topCitiesTotal }) => {
   const PAGE_SIZE_DEFAULT = 10
   const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
   const handleTableChange = (pagination) => {

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { Table } from 'antd'
+import ReactCountryFlag from 'react-country-flag'
+import { Pagination } from 'antd'
 
 const CitiesTable = ({ cities }) => {
   const PAGE_SIZE_DEFAULT = 10
@@ -7,23 +9,76 @@ const CitiesTable = ({ cities }) => {
   const handleTableChange = (pagination) => {
     setPageSize(pagination.pageSize)
   }
-  const citiesWithIndex = cities.map((c, i) => ({ ...c, rank: i + 1 }))
+  const citiesWithIndex = cities
+    .sort((a, b) =>
+      a.hotspot_count < b.hotspot_count
+        ? 1
+        : a.hotspot_count > b.hotspot_count
+        ? -1
+        : 0,
+    )
+    .map((c, i) => ({ ...c, rank: i + 1 }))
+
   return (
-    <Table
-      dataSource={citiesWithIndex}
-      columns={citiesColumns}
-      size="small"
-      rowKey="city_id"
-      pagination={{
-        pageSize,
-        showSizeChanger: cities.length > PAGE_SIZE_DEFAULT,
-        hideOnSinglePage: cities.length <= PAGE_SIZE_DEFAULT,
-        pageSizeOptions: [5, 10, 20, 50, 100],
-        position: 'bottomCenter',
-      }}
-      onChange={handleTableChange}
-      scroll={{ x: true }}
-    />
+    <>
+      <div className="hidden md:block">
+        <Table
+          dataSource={citiesWithIndex}
+          columns={citiesColumns}
+          size="small"
+          rowKey="city_id"
+          pagination={{
+            pageSize,
+            showSizeChanger: cities.length > PAGE_SIZE_DEFAULT,
+            hideOnSinglePage: cities.length <= PAGE_SIZE_DEFAULT,
+            pageSizeOptions: [5, 10, 20, 50, 100],
+            position: ['bottomCenter'],
+          }}
+          onChange={handleTableChange}
+          scroll={{ x: true }}
+        />
+      </div>
+      <div className="block md:hidden">
+        <div className="flex flex-col px-5 mb-2">
+          {citiesWithIndex.map((c, i, { length }) => {
+            return (
+              <div
+                // TODO: clean up styles using classnames package
+                className={`flex flex-col border-t border-0 border-l border-r border-solid px-3 py-2 border-gray-500 ${
+                  i === 0
+                    ? 'rounded-t-lg'
+                    : i === length - 1
+                    ? 'rounded-b-lg border-b'
+                    : 'border-b-0'
+                }`}
+              >
+                <p className="text-black text-md">
+                  <span className="text-gray-800 font-semibold">
+                    #{c.rank}{' '}
+                  </span>
+                  {c.long_city}
+                </p>
+                <div className="flex items-center justify-start">
+                  <ReactCountryFlag countryCode={c.short_country} svg />
+                  <span className="mr-2" />
+                  <span className="m-0 p-0">
+                    {c.long_state ? `${c.long_state}, ` : ''}
+                    {c.long_country}
+                  </span>
+                </div>
+
+                <div className="flex">
+                  <p className="text-black font-semibold text-md">
+                    {c.hotspot_count} hotspots
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        <Pagination />
+      </div>
+    </>
   )
 }
 
@@ -56,7 +111,13 @@ const citiesColumns = [
     title: 'Country',
     dataIndex: 'long_country',
     key: 'long_country',
-    render: (data) => <span>{data}</span>,
+    render: (data, row) => (
+      <div className="flex items-center justify-start">
+        <ReactCountryFlag countryCode={row.short_country} svg />
+        <div className="mr-2" />
+        <span className="m-0 p-0">{data}</span>
+      </div>
+    ),
   },
 ]
 

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -96,6 +96,8 @@ const CitiesTable = ({ cities }) => {
         <div className="flex items-center justify-center mt-5">
           <Pagination
             current={currentPage}
+            showSizeChanger
+            size="small"
             total={citiesWithIndex.length}
             pageSize={pageSize}
             onChange={(page, pageSize) => {

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -4,27 +4,28 @@ import ReactCountryFlag from 'react-country-flag'
 import { Pagination } from 'antd'
 import classNames from 'classnames'
 
-const CitiesTable = ({ cities }) => {
+const CitiesTable = ({ cities, topCities }) => {
   const PAGE_SIZE_DEFAULT = 10
   const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
   const handleTableChange = (pagination) => {
     setPageSize(pagination.pageSize)
   }
-  const citiesWithIndex = cities
+  const citiesToDisplay = topCities
     .sort((a, b) =>
-      a.hotspot_count < b.hotspot_count
+      a.hotspotCount < b.hotspotCount
         ? 1
-        : a.hotspot_count > b.hotspot_count
+        : a.hotspotCount > b.hotspotCount
         ? -1
         : 0,
     )
+    .slice(0, 100)
     .map((c, i) => ({ ...c, rank: i + 1 }))
 
   const [currentPage, setCurrentPage] = useState(1)
 
   const indexOfLastPost = currentPage * pageSize
   const indexOfFirstPost = indexOfLastPost - pageSize
-  const currentPageOfCities = citiesWithIndex.slice(
+  const currentPageOfCities = citiesToDisplay.slice(
     indexOfFirstPost,
     indexOfLastPost,
   )
@@ -33,10 +34,10 @@ const CitiesTable = ({ cities }) => {
     <>
       <div className="hidden md:block">
         <Table
-          dataSource={citiesWithIndex}
+          dataSource={citiesToDisplay}
           columns={citiesColumns}
           size="small"
-          rowKey="city_id"
+          rowKey="id"
           pagination={{
             pageSize,
             showSizeChanger: cities.length > PAGE_SIZE_DEFAULT,
@@ -76,17 +77,17 @@ const CitiesTable = ({ cities }) => {
                 <div className="pl-14">
                   <div className="px-3 py-2">
                     <div className="flex items-center justify-start">
-                      <ReactCountryFlag countryCode={c.short_country} svg />
+                      <ReactCountryFlag countryCode={c.shortCountry} svg />
                       <span className="mr-2" />
                       <p className="text-black text-md font-semibold m-0 p-0">
-                        {c.long_city}
+                        {c.longCity}
                         <span className="m-0 p-0 font-normal text-gray-600">
-                          , {c.long_country}
+                          , {c.longCountry}
                         </span>
                       </p>
                     </div>
                     <p className="text-purple-700 font-semibold text-md m-0 p-0">
-                      {c.hotspot_count?.toLocaleString()} hotspots
+                      {c.hotspotCount?.toLocaleString()} hotspots
                     </p>
                   </div>
                 </div>
@@ -99,7 +100,7 @@ const CitiesTable = ({ cities }) => {
             current={currentPage}
             showSizeChanger
             size="small"
-            total={citiesWithIndex.length}
+            total={citiesToDisplay.length}
             pageSize={pageSize}
             onChange={(page, pageSize) => {
               setCurrentPage(page)
@@ -121,31 +122,31 @@ const citiesColumns = [
   },
   {
     title: '# Hotspots Deployed',
-    dataIndex: 'hotspot_count',
-    key: 'hotspot_count',
+    dataIndex: 'hotspotCount',
+    key: 'hotspotCount',
     render: (data) => (
       <span className="text-purple-500 font-semibold">{data}</span>
     ),
   },
   {
     title: 'City',
-    dataIndex: 'long_city',
-    key: 'long_city',
+    dataIndex: 'longCity',
+    key: 'longCity',
     render: (data) => <span>{data}</span>,
   },
   {
     title: 'Region',
-    dataIndex: 'long_state',
-    key: 'long_state',
+    dataIndex: 'longState',
+    key: 'longState',
     render: (data) => <span>{data}</span>,
   },
   {
     title: 'Country',
-    dataIndex: 'long_country',
-    key: 'long_country',
+    dataIndex: 'longCountry',
+    key: 'longCountry',
     render: (data, row) => (
       <div className="flex items-center justify-start">
-        <ReactCountryFlag countryCode={row.short_country} svg />
+        <ReactCountryFlag countryCode={row.shortCountry} svg />
         <div className="mr-2" />
         <span className="m-0 p-0">{data}</span>
       </div>

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -19,6 +19,15 @@ const CitiesTable = ({ cities }) => {
     )
     .map((c, i) => ({ ...c, rank: i + 1 }))
 
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const indexOfLastPost = currentPage * pageSize
+  const indexOfFirstPost = indexOfLastPost - pageSize
+  const currentPageOfCities = citiesWithIndex.slice(
+    indexOfFirstPost,
+    indexOfLastPost,
+  )
+
   return (
     <>
       <div className="hidden md:block">
@@ -40,11 +49,11 @@ const CitiesTable = ({ cities }) => {
       </div>
       <div className="block md:hidden">
         <div className="flex flex-col px-5 mb-2">
-          {citiesWithIndex.map((c, i, { length }) => {
+          {currentPageOfCities.map((c, i, { length }) => {
             return (
               <div
                 // TODO: clean up styles using classnames package
-                className={`flex flex-col border-t border-0 border-l border-r border-solid px-3 py-2 border-gray-500 ${
+                className={`relative flex flex-col border-t border-0 border-l border-r border-solid border-gray-500 ${
                   i === 0
                     ? 'rounded-t-lg'
                     : i === length - 1
@@ -52,31 +61,49 @@ const CitiesTable = ({ cities }) => {
                     : 'border-b-0'
                 }`}
               >
-                <p className="text-black text-md">
-                  <span className="text-gray-800 font-semibold">
-                    #{c.rank}{' '}
-                  </span>
-                  {c.long_city}
-                </p>
-                <div className="flex items-center justify-start">
-                  <ReactCountryFlag countryCode={c.short_country} svg />
-                  <span className="mr-2" />
-                  <span className="m-0 p-0">
-                    {c.long_state ? `${c.long_state}, ` : ''}
-                    {c.long_country}
-                  </span>
+                <div
+                  className={`absolute top-0 bottom-0 w-14 flex items-center justify-center bg-purple-700${
+                    i === 0
+                      ? ' rounded-tl-lg'
+                      : i === length - 1
+                      ? ' rounded-bl-lg'
+                      : ''
+                  }`}
+                >
+                  <span className="text-white font-normal">{c.rank}</span>
                 </div>
-
-                <div className="flex">
-                  <p className="text-black font-semibold text-md">
-                    {c.hotspot_count} hotspots
-                  </p>
+                <div className="pl-14">
+                  <div className="px-3 py-2">
+                    <div className="flex items-center justify-start">
+                      <ReactCountryFlag countryCode={c.short_country} svg />
+                      <span className="mr-2" />
+                      <p className="text-black text-md font-semibold m-0 p-0">
+                        {c.long_city}
+                        <span className="m-0 p-0 font-normal text-gray-600">
+                          , {c.long_country}
+                        </span>
+                      </p>
+                    </div>
+                    <p className="text-purple-700 font-semibold text-md m-0 p-0">
+                      {c.hotspot_count?.toLocaleString()} hotspots
+                    </p>
+                  </div>
                 </div>
               </div>
             )
           })}
         </div>
-        <Pagination />
+        <div className="flex items-center justify-center mt-5">
+          <Pagination
+            current={currentPage}
+            total={citiesWithIndex.length}
+            pageSize={pageSize}
+            onChange={(page, pageSize) => {
+              setCurrentPage(page)
+              setPageSize(pageSize)
+            }}
+          />
+        </div>
       </div>
     </>
   )
@@ -93,7 +120,9 @@ const citiesColumns = [
     title: '# Hotspots Deployed',
     dataIndex: 'hotspot_count',
     key: 'hotspot_count',
-    render: (data) => <span>{data}</span>,
+    render: (data) => (
+      <span className="text-purple-500 font-semibold">{data}</span>
+    ),
   },
   {
     title: 'City',

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import { Table } from 'antd'
+
+const CitiesTable = ({ cities }) => {
+  const PAGE_SIZE_DEFAULT = 10
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_DEFAULT)
+  const handleTableChange = (pagination) => {
+    setPageSize(pagination.pageSize)
+  }
+  const citiesWithIndex = cities.map((c, i) => ({ ...c, rank: i + 1 }))
+  return (
+    <Table
+      dataSource={citiesWithIndex}
+      columns={citiesColumns}
+      size="small"
+      rowKey="city_id"
+      pagination={{
+        pageSize,
+        showSizeChanger: cities.length > PAGE_SIZE_DEFAULT,
+        hideOnSinglePage: cities.length <= PAGE_SIZE_DEFAULT,
+        pageSizeOptions: [5, 10, 20, 50, 100],
+        position: 'bottomCenter',
+      }}
+      onChange={handleTableChange}
+      scroll={{ x: true }}
+    />
+  )
+}
+
+const citiesColumns = [
+  {
+    title: 'Rank',
+    dataIndex: 'rank',
+    key: 'rank',
+    render: (data) => <span>{data}</span>,
+  },
+  {
+    title: '# Hotspots Deployed',
+    dataIndex: 'hotspot_count',
+    key: 'hotspot_count',
+    render: (data) => <span>{data}</span>,
+  },
+  {
+    title: 'City',
+    dataIndex: 'long_city',
+    key: 'long_city',
+    render: (data) => <span>{data}</span>,
+  },
+  {
+    title: 'Region',
+    dataIndex: 'long_state',
+    key: 'long_state',
+    render: (data) => <span>{data}</span>,
+  },
+  {
+    title: 'Country',
+    dataIndex: 'long_country',
+    key: 'long_country',
+    render: (data) => <span>{data}</span>,
+  },
+]
+
+export default CitiesTable

--- a/components/Hotspots/CitiesTable.js
+++ b/components/Hotspots/CitiesTable.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Table } from 'antd'
 import ReactCountryFlag from 'react-country-flag'
 import { Pagination } from 'antd'
+import classNames from 'classnames'
 
 const CitiesTable = ({ cities }) => {
   const PAGE_SIZE_DEFAULT = 10
@@ -53,22 +54,23 @@ const CitiesTable = ({ cities }) => {
             return (
               <div
                 // TODO: clean up styles using classnames package
-                className={`relative flex flex-col border-t border-0 border-l border-r border-solid border-gray-500 ${
-                  i === 0
-                    ? 'rounded-t-lg'
-                    : i === length - 1
-                    ? 'rounded-b-lg border-b'
-                    : 'border-b-0'
-                }`}
+                className={classNames(
+                  'relative flex flex-col border-t border-0 border-l border-r border-solid border-gray-500',
+                  {
+                    'rounded-t-lg': i === 0,
+                    'rounded-b-lg border-b': i === length - 1,
+                    'border-b-0': i !== 0 && i !== length - 1,
+                  },
+                )}
               >
                 <div
-                  className={`absolute top-0 bottom-0 w-14 flex items-center justify-center bg-purple-700${
-                    i === 0
-                      ? ' rounded-tl-lg'
-                      : i === length - 1
-                      ? ' rounded-bl-lg'
-                      : ''
-                  }`}
+                  className={classNames(
+                    'absolute top-0 bottom-0 w-14 flex items-center justify-center bg-purple-700',
+                    {
+                      'rounded-tl-lg': i === 0,
+                      'rounded-bl-lg': i === length - 1,
+                    },
+                  )}
                 >
                   <span className="text-white font-normal">{c.rank}</span>
                 </div>

--- a/components/Makers/MakersDashboard.js
+++ b/components/Makers/MakersDashboard.js
@@ -17,7 +17,7 @@ const MakersDashboard = ({ makers }) => {
     (m) => m.address === DEPRECATED_HELIUM_BURN_ADDR,
   )
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
       {makers.map((m, i) => {
         const dcBalanceObject = new Balance(
           m.balanceInfo.dcBalance.integerBalance,

--- a/components/Makers/MakersDashboard.js
+++ b/components/Makers/MakersDashboard.js
@@ -1,0 +1,146 @@
+import Link from 'next/link'
+import { Balance, CurrencyType } from '@helium/currency'
+import DCIcon from '../Icons/DC'
+import HotspotSimpleIcon from '../Icons/HotspotSimple'
+import BurnIcon from '../Icons/BurnIcon'
+import LocationIcon from '../Icons/Location'
+import InfoIcon from '../Icons/Info'
+import InternalLink from '../Icons/InternalLink'
+import {
+  DEPRECATED_HELIUM_MAKER_ADDR,
+  DEPRECATED_HELIUM_BURN_ADDR,
+} from './utils'
+import { Tooltip } from 'antd'
+
+const MakersDashboard = ({ makers }) => {
+  const oldHeliumBurnAddrData = makers.find(
+    (m) => m.address === DEPRECATED_HELIUM_BURN_ADDR,
+  )
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+      {makers.map((m, i) => {
+        const dcBalanceObject = new Balance(
+          m.balanceInfo.dcBalance.integerBalance,
+          CurrencyType.dataCredit,
+        )
+        const addsPlusAssertsLeft = Math.floor(
+          m.balanceInfo.dcBalance.integerBalance / 5000000,
+        )
+
+        const hntBurnedAmountInBones =
+          m.address === DEPRECATED_HELIUM_MAKER_ADDR
+            ? // for the "Helium Inc (Old)" maker account, use the account data of the one where the burns happened instead
+              oldHeliumBurnAddrData.txns.tokenBurnAmountInBones
+            : m.txns.tokenBurnAmountInBones
+        const hntBurned = new Balance(
+          hntBurnedAmountInBones,
+          CurrencyType.networkToken,
+        )
+
+        if (m.address !== DEPRECATED_HELIUM_BURN_ADDR)
+          return (
+            <div className="border border-solid border-gray-300 rounded-lg shadow-sm bg-white hover:bg-white">
+              <div className="p-5 pb-4">
+                <div className="flex flex-row items-center justify-start">
+                  <p className="text-sm font-semibold m-0 text-black">
+                    {m.name}
+                  </p>
+                  {m.address === DEPRECATED_HELIUM_MAKER_ADDR && (
+                    <Tooltip
+                      placement="top"
+                      title="This Maker address used genesis Data Credits to onboard Hotspots and is no longer in use."
+                    >
+                      <span className="ml-2 flex flex-row items-center justify-center">
+                        <InfoIcon className="text-gray-600 h-4 w-4" />
+                      </span>
+                    </Tooltip>
+                  )}
+                </div>
+                <p className="text-sm font-light m-0 text-gray-600">
+                  {m.address.slice(0, 5)}...{m.address.slice(-5)}
+                </p>
+                <div className="pt-2.5 flex flex-row items-center justify-start">
+                  <DCIcon className="h-3 w-auto mr-2" />
+                  <p className="text-base font-semibold m-0 text-black">
+                    {dcBalanceObject.toString()}
+                  </p>
+                </div>
+              </div>
+              <div className="rounded-b-lg p-5 pt-4 bg-gray-100 border-t border-r-0 border-b-0 border-l-0 border-gray-300 border-solid flex flex-col space-y-2">
+                <div className="flex flex-row items-center justify-start">
+                  <HotspotSimpleIcon className="text-green-500 w-3 h-auto" />
+                  <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
+                    {m.txns.addGatewayTxns.toLocaleString()}
+                    <span className="ml-1 font-light text-gray-600">
+                      Hotspots Added
+                    </span>
+                  </p>
+                </div>
+                <div className="flex flex-row items-center justify-start">
+                  <LocationIcon className="text-pink-500 w-3 h-auto" />
+                  <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
+                    {m.txns.assertLocationTxns.toLocaleString()}
+                    <span className="ml-1 font-light text-gray-600">
+                      Locations Asserted
+                    </span>
+                  </p>
+                </div>
+                <div className="flex flex-row items-center justify-start">
+                  <BurnIcon className="text-orange-300 w-3 h-auto" />
+                  <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
+                    {hntBurned.toString(2).slice(0, -4)}
+                    <span className="ml-1 font-light text-gray-600">
+                      HNT burned
+                    </span>
+                  </p>
+                  {m.address === DEPRECATED_HELIUM_MAKER_ADDR && (
+                    <Tooltip
+                      placement="top"
+                      title={`The number represented here was burned by the wallet with the address: ${DEPRECATED_HELIUM_BURN_ADDR}.`}
+                    >
+                      <span className="ml-2 flex flex-row items-center justify-center">
+                        <InfoIcon className="text-gray-600 h-4 w-4" />
+                      </span>
+                    </Tooltip>
+                  )}
+                </div>
+                {m.address === DEPRECATED_HELIUM_MAKER_ADDR ? (
+                  <p className="text-sm pt-2.5 m-0 font-medium text-gray-600">
+                    Genesis Hotspots:{' '}
+                    <span className="text-gray-700">{m.genesisHotspots}</span>
+                  </p>
+                ) : (
+                  <div className="flex flex-row items-center justify-start pt-2.5">
+                    <p className="text-sm m-0 font-light text-gray-600">
+                      Adds + Asserts Left:{' '}
+                      <span className="text-gray-700 font-semibold">
+                        {addsPlusAssertsLeft.toLocaleString()}
+                      </span>
+                    </p>
+                    <Tooltip
+                      placement="top"
+                      title={`The number of hotspots this Maker could afford to onboard given their current DC balance, assuming a cost of ${(5000000).toLocaleString()} DC for each hotspot (${(4000000).toLocaleString()} DC to add it to the blockchain, and ${(1000000).toLocaleString()} DC to assert its location).`}
+                    >
+                      <span className="ml-2 flex flex-row items-center justify-center">
+                        <InfoIcon className="text-gray-600 h-4 w-4" />
+                      </span>
+                    </Tooltip>
+                  </div>
+                )}
+                <div className="">
+                  <Link href={`/accounts/${m.address}`}>
+                    <a className="px-4 py-2 text-gray-700 font-medium bg-white mt-4 shadow-md transition-all hover:shadow-lg rounded-lg flex flex-row justify-between items-center">
+                      View account
+                      <InternalLink className="h-4 w-auto text-gray-600" />
+                    </a>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          )
+      })}
+    </div>
+  )
+}
+
+export default MakersDashboard

--- a/data/stats.js
+++ b/data/stats.js
@@ -33,3 +33,19 @@ export const useStats = (initialData) => {
     isError: error,
   }
 }
+
+export const fetchCitiesByOnline = async () => {
+  const citiesResOnline = await fetch(
+    'https://api.helium.io/v1/cities?order=online_count',
+  )
+  const { data } = await citiesResOnline.json()
+  return JSON.parse(JSON.stringify(data))
+}
+
+export const fetchCitiesByTotal = async () => {
+  const citiesResTotal = await fetch(
+    'https://api.helium.io/v1/cities?order=hotspot_count',
+  )
+  const { data } = await citiesResTotal.json()
+  return JSON.parse(JSON.stringify(data))
+}

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -71,7 +71,7 @@ const Hotspots = ({
         title="Hotspot Network Growth"
         chart={<HotspotChart data={hotspotGrowth} />}
       />
-      <div className="max-w-screen-xl mx-auto px-2 sm:px-10 pt-5 pb-24">
+      <div className="max-w-screen-xl mx-auto px-2 sm:px-3 md:px-4 lg:px-10 pt-5 pb-24">
         {/* Stats section */}
         <section className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5">
           <Widget

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -53,6 +53,9 @@ const Hotspots = ({
     (m) => m.address === DEPRECATED_HELIUM_BURN_ADDR,
   )
 
+  const hotspotAddedInLastDay =
+    hotspotGrowth[hotspotGrowth.length - 1].count -
+    hotspotGrowth[hotspotGrowth.length - 2].count
   return (
     <AppLayout
       title={'Hotspots'}
@@ -263,8 +266,8 @@ export async function getStaticProps() {
 
   const makers = await getMakersData()
 
-  Array.from({ length: 39 }, (x, i) => {
-    const date = sub(now, { weeks: i + 1 })
+  Array.from({ length: 364 }, (x, i) => {
+    const date = sub(now, { days: i + 1 })
     // count hotspots where the time added is earlier than the given date
     const count = countBy(
       hotspots,

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -56,6 +56,7 @@ const Hotspots = ({
   const hotspotAddedInLastDay =
     hotspotGrowth[hotspotGrowth.length - 1].count -
     hotspotGrowth[hotspotGrowth.length - 2].count
+
   return (
     <AppLayout
       title={'Hotspots'}

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -15,6 +15,7 @@ import Widget from '../../components/Home/Widget'
 import dynamic from 'next/dynamic'
 import MakersDashboard from '../../components/Makers/MakersDashboard'
 import { getMakersData } from '../../components/Makers/utils.js'
+import { fetchCitiesByOnline, fetchCitiesByTotal } from '../../data/stats'
 
 const MiniCoverageMap = dynamic(
   () => import('../../components/CoverageMap/MiniCoverageMap'),
@@ -176,15 +177,8 @@ export async function getStaticProps() {
 
   const latestHotspots = JSON.parse(JSON.stringify(hotspots.slice(0, 20)))
 
-  const citiesResOnline = await fetch(
-    'https://api.helium.io/v1/cities?order=online_count',
-  )
-  const { data: topCities } = await citiesResOnline.json()
-
-  const citiesResTotal = await fetch(
-    'https://api.helium.io/v1/cities?order=hotspot_count',
-  )
-  const { data: topCitiesTotal } = await citiesResTotal.json()
+  const topCities = await fetchCitiesByOnline()
+  const topCitiesTotal = await fetchCitiesByTotal()
 
   return {
     props: {
@@ -193,7 +187,6 @@ export async function getStaticProps() {
       latestHotspots,
       stats,
       makers,
-      // cities,
       topCities,
       topCitiesTotal,
     },

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -91,7 +91,7 @@ const Hotspots = ({
 
         {/* Top cities section */}
         <section className="mt-5 bg-white rounded-lg py-5">
-          <h2 className="font-medium text-base pl-6 pb-4 m-0">Top Cities</h2>
+          <h2 className="font-medium text-base pl-6 pb-2 m-0">Top Cities</h2>
           <CitiesTable
             cities={cities}
             topCities={topCities}
@@ -157,38 +157,57 @@ export async function getStaticProps() {
   const citiesRes = await fetch('https://api.helium.io/v1/cities?sort=hotspots')
   const { data: cities } = await citiesRes.json()
 
-  const topCitiesTotal = []
   const topCities = []
   hotspots.map((h) => {
-    const isOnlineAndAsserted = h.status.online === 'online' && h.lat && h.lng
-    // see if another hotspot from this city has already been counted
-    const cityIndex = topCities.findIndex((c) => c.id === h.geocode.cityId)
-    const newCity = {
-      id: h.geocode.cityId,
-      shortCity: h.geocode.shortCity,
-      longCity: h.geocode.longCity,
-      shortState: h.geocode.shortState,
-      longState: h.geocode.longState,
-      shortCountry: h.geocode.shortCountry,
-      longCountry: h.geocode.longCountry,
-      hotspotCount: isOnlineAndAsserted ? 1 : 0,
+    const isOnlineAndAsserted =
+      h.status.online === 'online' &&
+      h.location !== null &&
+      h.geocode.cityId !== null
+    if (isOnlineAndAsserted) {
+      // see if another hotspot from this city has already been counted
+      const cityIndex = topCities.findIndex((c) => c.id === h.geocode.cityId)
+      if (cityIndex === -1) {
+        // if it hasn't, create a new city in our topCities array
+        const newCity = {
+          id: h.geocode.cityId,
+          shortCity: h.geocode.shortCity,
+          longCity: h.geocode.longCity,
+          shortState: h.geocode.shortState,
+          longState: h.geocode.longState,
+          shortCountry: h.geocode.shortCountry,
+          longCountry: h.geocode.longCountry,
+          hotspotCount: isOnlineAndAsserted ? 1 : 0,
+        }
+        topCities.push(newCity)
+      } else {
+        // if it has, increment that city's hotspotCount
+        if (isOnlineAndAsserted) topCities[cityIndex].hotspotCount++
+      }
     }
-    if (cityIndex === -1) {
-      // if it hasn't, create a new city in our topCities array
-      topCities.push(newCity)
-    } else {
-      // if it has, increment that city's hotspotCount
-      if (isOnlineAndAsserted) topCities[cityIndex].hotspotCount++
-    }
+  })
 
+  const topCitiesTotal = []
+  hotspots.map((h) => {
+    // see if another hotspot from this city has already been counted
     const cityIndexTotal = topCitiesTotal.findIndex(
       (c) => c.id === h.geocode.cityId,
     )
     if (cityIndexTotal === -1) {
-      newCity.hotspotCount = 1
+      // if it hasn't, create a new city in our topCities array
+      const newCity = {
+        id: h.geocode.cityId,
+        shortCity: h.geocode.shortCity,
+        longCity: h.geocode.longCity,
+        shortState: h.geocode.shortState,
+        longState: h.geocode.longState,
+        shortCountry: h.geocode.shortCountry,
+        longCountry: h.geocode.longCountry,
+        hotspotCount: 1,
+      }
       topCitiesTotal.push(newCity)
     } else {
-      topCitiesTotal[cityIndexTotal].hotspotCount++
+      // if it has, increment that city's hotspotCount
+      if (h.location !== null) topCitiesTotal[cityIndexTotal].hotspotCount++
     }
   })
 

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -5,6 +5,7 @@ import AppLayout from '../../components/AppLayout'
 import { Tooltip } from 'antd'
 import HotspotChart from '../../components/Hotspots/HotspotChart'
 import LatestHotspotsTable from '../../components/Hotspots/LatestHotspotsTable'
+import CitiesTable from '../../components/Hotspots/CitiesTable'
 import { fetchStats, useStats } from '../../data/stats'
 import { sub, compareAsc, getUnixTime } from 'date-fns'
 import { useLatestHotspots } from '../../data/hotspots'
@@ -41,6 +42,7 @@ const Hotspots = ({
   latestHotspots: initialLatestHotspots,
   stats: initialStats,
   makers,
+  cities,
 }) => {
   const {
     stats: { totalHotspots, totalCities, totalCountries },
@@ -95,6 +97,12 @@ const Hotspots = ({
           <a href="/coverage">
             <MiniCoverageMap zoomLevel={0.9} />
           </a>
+        </section>
+
+        {/* Top cities section */}
+        <section className="mt-5 bg-white rounded-lg py-5">
+          <h2 className="font-medium text-base pl-6 pb-4 m-0">Top Cities</h2>
+          <CitiesTable cities={cities} />
         </section>
 
         {/* Makers section */}
@@ -276,6 +284,9 @@ export async function getStaticProps() {
 
   const latestHotspots = JSON.parse(JSON.stringify(hotspots.slice(0, 20)))
 
+  const citiesRes = await fetch('https://api.helium.io/v1/cities?sort=hotspots')
+  const { data: cities } = await citiesRes.json()
+
   return {
     props: {
       hotspotGrowth,
@@ -283,6 +294,7 @@ export async function getStaticProps() {
       latestHotspots,
       stats,
       makers,
+      cities,
     },
     revalidate: 60,
   }

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -30,7 +30,6 @@ const Hotspots = ({
   latestHotspots: initialLatestHotspots,
   stats: initialStats,
   makers,
-  cities,
   topCities,
   topCitiesTotal,
 }) => {
@@ -119,11 +118,7 @@ const Hotspots = ({
         {/* Top cities section */}
         <section className="mt-5 bg-white rounded-lg py-5">
           <h2 className="font-medium text-base pl-6 pb-2 m-0">Top Cities</h2>
-          <CitiesTable
-            cities={cities}
-            topCities={topCities}
-            topCitiesTotal={topCitiesTotal}
-          />
+          <CitiesTable topCities={topCities} topCitiesTotal={topCitiesTotal} />
         </section>
 
         {/* Makers section */}
@@ -181,62 +176,15 @@ export async function getStaticProps() {
 
   const latestHotspots = JSON.parse(JSON.stringify(hotspots.slice(0, 20)))
 
-  const citiesRes = await fetch('https://api.helium.io/v1/cities?sort=hotspots')
-  const { data: cities } = await citiesRes.json()
+  const citiesResOnline = await fetch(
+    'https://api.helium.io/v1/cities?order=online_count',
+  )
+  const { data: topCities } = await citiesResOnline.json()
 
-  const topCities = []
-  hotspots.map((h) => {
-    const isOnlineAndAsserted =
-      h.status.online === 'online' &&
-      h.location !== null &&
-      h.geocode.cityId !== null
-    if (isOnlineAndAsserted) {
-      // see if another hotspot from this city has already been counted
-      const cityIndex = topCities.findIndex((c) => c.id === h.geocode.cityId)
-      if (cityIndex === -1) {
-        // if it hasn't, create a new city in our topCities array
-        const newCity = {
-          id: h.geocode.cityId,
-          shortCity: h.geocode.shortCity,
-          longCity: h.geocode.longCity,
-          shortState: h.geocode.shortState,
-          longState: h.geocode.longState,
-          shortCountry: h.geocode.shortCountry,
-          longCountry: h.geocode.longCountry,
-          hotspotCount: isOnlineAndAsserted ? 1 : 0,
-        }
-        topCities.push(newCity)
-      } else {
-        // if it has, increment that city's hotspotCount
-        if (isOnlineAndAsserted) topCities[cityIndex].hotspotCount++
-      }
-    }
-  })
-
-  const topCitiesTotal = []
-  hotspots.map((h) => {
-    // see if another hotspot from this city has already been counted
-    const cityIndexTotal = topCitiesTotal.findIndex(
-      (c) => c.id === h.geocode.cityId,
-    )
-    if (cityIndexTotal === -1) {
-      // if it hasn't, create a new city in our topCities array
-      const newCity = {
-        id: h.geocode.cityId,
-        shortCity: h.geocode.shortCity,
-        longCity: h.geocode.longCity,
-        shortState: h.geocode.shortState,
-        longState: h.geocode.longState,
-        shortCountry: h.geocode.shortCountry,
-        longCountry: h.geocode.longCountry,
-        hotspotCount: 1,
-      }
-      topCitiesTotal.push(newCity)
-    } else {
-      // if it has, increment that city's hotspotCount
-      if (h.location !== null) topCitiesTotal[cityIndexTotal].hotspotCount++
-    }
-  })
+  const citiesResTotal = await fetch(
+    'https://api.helium.io/v1/cities?order=hotspot_count',
+  )
+  const { data: topCitiesTotal } = await citiesResTotal.json()
 
   return {
     props: {
@@ -245,7 +193,7 @@ export async function getStaticProps() {
       latestHotspots,
       stats,
       makers,
-      cities,
+      // cities,
       topCities,
       topCitiesTotal,
     },

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Client from '@helium/http'
 import countBy from 'lodash/countBy'
 import AppLayout from '../../components/AppLayout'
-import { Tooltip } from 'antd'
 import HotspotChart from '../../components/Hotspots/HotspotChart'
 import LatestHotspotsTable from '../../components/Hotspots/LatestHotspotsTable'
 import CitiesTable from '../../components/Hotspots/CitiesTable'
@@ -14,19 +13,8 @@ import TopChart from '../../components/AppLayout/TopChart'
 import HotspotsImg from '../../public/images/hotspots.svg'
 import Widget from '../../components/Home/Widget'
 import dynamic from 'next/dynamic'
-import Link from 'next/link'
-import { Balance, CurrencyType } from '@helium/currency'
-import DCIcon from '../../components/Icons/DC'
-import HotspotSimpleIcon from '../../components/Icons/HotspotSimple'
-import BurnIcon from '../../components/Icons/BurnIcon'
-import LocationIcon from '../../components/Icons/Location'
-import InfoIcon from '../../components/Icons/Info'
-import InternalLink from '../../components/Icons/InternalLink'
-import {
-  DEPRECATED_HELIUM_MAKER_ADDR,
-  DEPRECATED_HELIUM_BURN_ADDR,
-  getMakersData,
-} from '../../components/Makers/utils'
+import MakersDashboard from '../../components/Makers/MakersDashboard'
+import { getMakersData } from '../../components/Makers/utils.js'
 
 const MiniCoverageMap = dynamic(
   () => import('../../components/CoverageMap/MiniCoverageMap'),
@@ -48,10 +36,6 @@ const Hotspots = ({
     stats: { totalHotspots, totalCities, totalCountries },
   } = useStats(initialStats)
   const { latestHotspots } = useLatestHotspots(initialLatestHotspots)
-
-  const oldHeliumBurnAddrData = makers.find(
-    (m) => m.address === DEPRECATED_HELIUM_BURN_ADDR,
-  )
 
   const hotspotAddedInLastDay =
     hotspotGrowth[hotspotGrowth.length - 1].count -
@@ -112,131 +96,7 @@ const Hotspots = ({
         {/* Makers section */}
         <section className="mt-5 bg-white rounded-lg p-5 pb-10">
           <h2 className="font-medium text-base pb-4 m-0">Makers</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
-            {makers.map((m, i) => {
-              const dcBalanceObject = new Balance(
-                m.balanceInfo.dcBalance.integerBalance,
-                CurrencyType.dataCredit,
-              )
-              const addsPlusAssertsLeft = Math.floor(
-                m.balanceInfo.dcBalance.integerBalance / 5000000,
-              )
-
-              const hntBurnedAmountInBones =
-                m.address === DEPRECATED_HELIUM_MAKER_ADDR
-                  ? // for the "Helium Inc (Old)" maker account, use the account data of the one where the burns happened instead
-                    oldHeliumBurnAddrData.txns.tokenBurnAmountInBones
-                  : m.txns.tokenBurnAmountInBones
-              const hntBurned = new Balance(
-                hntBurnedAmountInBones,
-                CurrencyType.networkToken,
-              )
-
-              if (m.address !== DEPRECATED_HELIUM_BURN_ADDR)
-                return (
-                  <div className="border border-solid border-gray-300 rounded-lg shadow-sm bg-white hover:bg-white">
-                    <div className="p-5 pb-4">
-                      <div className="flex flex-row items-center justify-start">
-                        <p className="text-sm font-semibold m-0 text-black">
-                          {m.name}
-                        </p>
-                        {m.address === DEPRECATED_HELIUM_MAKER_ADDR && (
-                          <Tooltip
-                            placement="top"
-                            title="This Maker address used genesis Data Credits to onboard Hotspots and is no longer in use."
-                          >
-                            <span className="ml-2 flex flex-row items-center justify-center">
-                              <InfoIcon className="text-gray-600 h-4 w-4" />
-                            </span>
-                          </Tooltip>
-                        )}
-                      </div>
-                      <p className="text-sm font-light m-0 text-gray-600">
-                        {m.address.slice(0, 5)}...{m.address.slice(-5)}
-                      </p>
-                      <div className="pt-2.5 flex flex-row items-center justify-start">
-                        <DCIcon className="h-3 w-auto mr-2" />
-                        <p className="text-base font-semibold m-0 text-black">
-                          {dcBalanceObject.toString()}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="rounded-b-lg p-5 pt-4 bg-gray-100 border-t border-r-0 border-b-0 border-l-0 border-gray-300 border-solid flex flex-col space-y-2">
-                      <div className="flex flex-row items-center justify-start">
-                        <HotspotSimpleIcon className="text-green-500 w-3 h-auto" />
-                        <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
-                          {m.txns.addGatewayTxns.toLocaleString()}
-                          <span className="ml-1 font-light text-gray-600">
-                            Hotspots Added
-                          </span>
-                        </p>
-                      </div>
-                      <div className="flex flex-row items-center justify-start">
-                        <LocationIcon className="text-pink-500 w-3 h-auto" />
-                        <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
-                          {m.txns.assertLocationTxns.toLocaleString()}
-                          <span className="ml-1 font-light text-gray-600">
-                            Locations Asserted
-                          </span>
-                        </p>
-                      </div>
-                      <div className="flex flex-row items-center justify-start">
-                        <BurnIcon className="text-orange-300 w-3 h-auto" />
-                        <p className="text-sm ml-1 font-semibold m-0 text-gray-700">
-                          {hntBurned.toString(2).slice(0, -4)}
-                          <span className="ml-1 font-light text-gray-600">
-                            HNT burned
-                          </span>
-                        </p>
-                        {m.address === DEPRECATED_HELIUM_MAKER_ADDR && (
-                          <Tooltip
-                            placement="top"
-                            title={`The number represented here was burned by the wallet with the address: ${DEPRECATED_HELIUM_BURN_ADDR}.`}
-                          >
-                            <span className="ml-2 flex flex-row items-center justify-center">
-                              <InfoIcon className="text-gray-600 h-4 w-4" />
-                            </span>
-                          </Tooltip>
-                        )}
-                      </div>
-                      {m.address === DEPRECATED_HELIUM_MAKER_ADDR ? (
-                        <p className="text-sm pt-2.5 m-0 font-medium text-gray-600">
-                          Genesis Hotspots:{' '}
-                          <span className="text-gray-700">
-                            {m.genesisHotspots}
-                          </span>
-                        </p>
-                      ) : (
-                        <div className="flex flex-row items-center justify-start pt-2.5">
-                          <p className="text-sm m-0 font-light text-gray-600">
-                            Adds + Asserts Left:{' '}
-                            <span className="text-gray-700 font-semibold">
-                              {addsPlusAssertsLeft.toLocaleString()}
-                            </span>
-                          </p>
-                          <Tooltip
-                            placement="top"
-                            title={`The number of hotspots this Maker could afford to onboard given their current DC balance, assuming a cost of ${(5000000).toLocaleString()} DC for each hotspot (${(4000000).toLocaleString()} DC to add it to the blockchain, and ${(1000000).toLocaleString()} DC to assert its location).`}
-                          >
-                            <span className="ml-2 flex flex-row items-center justify-center">
-                              <InfoIcon className="text-gray-600 h-4 w-4" />
-                            </span>
-                          </Tooltip>
-                        </div>
-                      )}
-                      <div className="">
-                        <Link href={`/accounts/${m.address}`}>
-                          <a className="px-4 py-2 text-gray-700 font-medium bg-white mt-4 shadow-md transition-all hover:shadow-lg rounded-lg flex flex-row justify-between items-center">
-                            View account
-                            <InternalLink className="h-4 w-auto text-gray-600" />
-                          </a>
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                )
-            })}
-          </div>
+          <MakersDashboard makers={makers} />
         </section>
 
         {/* Latest hotspots section */}

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -31,6 +31,7 @@ const Hotspots = ({
   stats: initialStats,
   makers,
   cities,
+  topCities,
 }) => {
   const {
     stats: { totalHotspots, totalCities, totalCountries },
@@ -90,7 +91,7 @@ const Hotspots = ({
         {/* Top cities section */}
         <section className="mt-5 bg-white rounded-lg py-5">
           <h2 className="font-medium text-base pl-6 pb-4 m-0">Top Cities</h2>
-          <CitiesTable cities={cities} />
+          <CitiesTable cities={cities} topCities={topCities} />
         </section>
 
         {/* Makers section */}
@@ -151,6 +152,31 @@ export async function getStaticProps() {
   const citiesRes = await fetch('https://api.helium.io/v1/cities?sort=hotspots')
   const { data: cities } = await citiesRes.json()
 
+  const topCities = []
+  hotspots.map((h) => {
+    // filter offline / unasserted hotspots
+    if (h.status.online === 'online' && h.lat && h.lng) {
+      // see if another hotspot from this city has already been counted
+      const cityIndex = topCities.findIndex((c) => c.id === h.geocode.cityId)
+      if (cityIndex === -1) {
+        // if it hasn't, create a new city in our topCities array
+        topCities.push({
+          id: h.geocode.cityId,
+          hotspotCount: 1,
+          shortCity: h.geocode.shortCity,
+          longCity: h.geocode.longCity,
+          shortState: h.geocode.shortState,
+          longState: h.geocode.longState,
+          shortCountry: h.geocode.shortCountry,
+          longCountry: h.geocode.longCountry,
+        })
+      } else {
+        // if it has, increment that city's hotspotCount
+        topCities[cityIndex].hotspotCount++
+      }
+    }
+  })
+
   return {
     props: {
       hotspotGrowth,
@@ -159,6 +185,7 @@ export async function getStaticProps() {
       stats,
       makers,
       cities,
+      topCities,
     },
     revalidate: 60,
   }

--- a/pages/hotspots/index.js
+++ b/pages/hotspots/index.js
@@ -39,9 +39,16 @@ const Hotspots = ({
   } = useStats(initialStats)
   const { latestHotspots } = useLatestHotspots(initialLatestHotspots)
 
-  const hotspotAddedInLastDay =
-    hotspotGrowth[hotspotGrowth.length - 1].count -
-    hotspotGrowth[hotspotGrowth.length - 2].count
+  const days = hotspotGrowth.length
+  const hotspotGrowth24Hours =
+    hotspotGrowth[days - 1].count - hotspotGrowth[days - 2].count
+  const hotspotGrowth24HourPreviousPeriod =
+    hotspotGrowth[days - 2].count - hotspotGrowth[days - 3].count
+
+  const hotspotGrowth30Days =
+    hotspotGrowth[days - 1].count - hotspotGrowth[days - 31].count
+  const hotspotGrowth30DayPreviousPeriod =
+    hotspotGrowth[days - 31].count - hotspotGrowth[days - 61].count
 
   return (
     <AppLayout
@@ -57,9 +64,9 @@ const Hotspots = ({
         title="Hotspot Network Growth"
         chart={<HotspotChart data={hotspotGrowth} />}
       />
-      <div className="max-w-screen-xl mx-auto px-2 sm:px-3 md:px-4 lg:px-10 pt-5 pb-24">
+      <div className="max-w-screen-lg mx-auto px-2 sm:px-3 md:px-4 lg:px-10 pt-5 pb-24">
         {/* Stats section */}
-        <section className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5">
+        <section className="grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-3 lg:gap-4">
           <Widget
             title="Total Hotspots"
             value={totalHotspots.toLocaleString()}
@@ -76,6 +83,26 @@ const Hotspots = ({
             change={(onlineHotspotCount / totalHotspots) * 100}
             changeSuffix="%"
             changeIsAmbivalent
+          />
+          <Widget
+            title="Hotspots Added in Last 24 Hours"
+            value={hotspotGrowth24Hours.toLocaleString()}
+            change={
+              ((hotspotGrowth24Hours - hotspotGrowth24HourPreviousPeriod) /
+                hotspotGrowth24HourPreviousPeriod) *
+              100
+            }
+            changeSuffix="%"
+          />
+          <Widget
+            title="Hotspots Added in Last 30 Days"
+            value={hotspotGrowth30Days.toLocaleString()}
+            change={
+              ((hotspotGrowth30Days - hotspotGrowth30DayPreviousPeriod) /
+                hotspotGrowth30DayPreviousPeriod) *
+              100
+            }
+            changeSuffix="%"
           />
           <Widget title="Cities" value={totalCities.toLocaleString()} />
           <Widget title="Countries" value={totalCountries.toLocaleString()} />

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -640,6 +640,14 @@ tr.ant-table-expanded-row-level-1 > td.ant-table-cell {
   padding: 0 0 0 24px;
 }
 
+.ant-checkbox-override-purple .ant-checkbox-checked .ant-checkbox-inner {
+  background-color: #5850eb !important;
+  border-color: #5850eb !important;
+}
+.ant-checkbox-override-purple .ant-checkbox-checked::after {
+  border: 1px solid #5850eb !important;
+}
+
 .ant-checkbox-override .ant-checkbox-checked .ant-checkbox-inner {
   background-color: #2e3750;
   border-color: #2e3750;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,7 @@ module.exports = {
       },
       purple: {
         500: '#A667F6',
+        700: '#5850EB',
       },
       green: {
         100: '#474DFF',


### PR DESCRIPTION
Will close #283 

Adds a "Top Cities" section to /hotspots:
![Screen Shot 2021-03-31 at 11 20 24 AM](https://user-images.githubusercontent.com/10648471/113192059-2a800900-9213-11eb-813c-547ef4eeb71d.png)
![Screen Shot 2021-03-31 at 11 20 32 AM](https://user-images.githubusercontent.com/10648471/113192063-2b189f80-9213-11eb-9c38-542419ab9210.png)

The city data right now is being calculated by looping through all hotspots in the `getStaticProps` function on the `/hotspots` page and tallying the cities by the `.geocode.cityId` field of each hotspot, but it should be an easy change to use the API once it's ready: something like `/v1/cities?order=online` and `/v1/cities?order=total` (https://github.com/helium/blockchain-http/issues/207)

I also fixed the data fetching for the maker dashboard to be more efficient, using the new `/activity/count?filter_types=` endpoint to count the number of `assert_location_v1` & `add_gateway_v1` transactions. (Still need to loop through `token_burn_v1` for now though, because we need to sum the `.amount` field within those txns.) And also turned the MakerDashboard into a reusable component.

I also made the hotspots chart at the top show daily data points instead of weekly, as well as added some new stat widgets to the top of the page ("Hotspots Added in Last 24 Hours" and "Hotspots Added in Last 30 Days")