### PR TITLE
Initialize MapBox within component

### DIFF
--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -8,10 +8,6 @@ import ScaleControl from '../ScaleControl'
 import MapButton from './MapButton'
 import WitnessIcon from './WitnessIcon'
 
-const Mapbox = ReactMapboxGl({
-  accessToken: process.env.NEXT_PUBLIC_MAPBOX_KEY,
-})
-
 const styles = {
   selectedMarker: {
     width: 14,
@@ -64,6 +60,10 @@ const HotspotMapbox = ({
   nearbyHotspots = [],
   router,
 }) => {
+  const Mapbox = ReactMapboxGl({
+    accessToken: process.env.NEXT_PUBLIC_MAPBOX_KEY,
+  })
+  
   const [showWitnesses, setShowWitnesses] = useState(true)
   const [showNearbyHotspots, setShowNearbyHotspots] = useState(true)
 


### PR DESCRIPTION
Continuation of https://github.com/helium/explorer/pull/261

Fixes centering issue on initial render.

From what I understand this is due to the how the Map is initialized, would like someone to test this out on their machine to make sure it's working.