### PR TITLE
Cap witness distance

### DIFF
--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -1,12 +1,14 @@
 import { useState } from 'react'
 import { Tooltip } from 'antd'
-import { findBounds } from '../Txns/utils'
+import { findBounds, haversineDistance } from '../Txns/utils'
 import animalHash from 'angry-purple-tiger'
 import ReactMapboxGl, { Layer, Marker, Feature } from 'react-mapbox-gl'
 import { withRouter } from 'next/router'
 import ScaleControl from '../ScaleControl'
 import MapButton from './MapButton'
 import WitnessIcon from './WitnessIcon'
+
+const MAX_WITNESS_DISTANCE_THRESHOLD = 200
 
 const Mapbox = ReactMapboxGl({
   accessToken: process.env.NEXT_PUBLIC_MAPBOX_KEY,
@@ -74,7 +76,11 @@ const HotspotMapbox = ({
 
   // include witnesses in centering / zooming logic
   witnesses.map((w) => {
-    if (showWitnesses) boundsLocations.push({ lng: w?.lng, lat: w?.lat })
+    const distance = haversineDistance(hotspot?.lng, hotspot?.lat, w.lng, w.lat)
+    console.log(distance);
+    if (showWitnesses && distance <= MAX_WITNESS_DISTANCE_THRESHOLD) {
+      boundsLocations.push({ lng: w?.lng, lat: w?.lat })
+    }
   })
 
   // include nearby hotspots in centering / zooming logic
@@ -145,39 +151,43 @@ const HotspotMapbox = ({
           />
 
           {showWitnesses &&
-            witnesses.map((w) => (
-              <>
-                <Tooltip title={animalHash(w.address)}>
-                  <Marker
-                    key={w.address}
-                    style={styles.witnessMarker}
-                    anchor="center"
-                    coordinates={[w.lng, w.lat]}
-                    onClick={() => router.push(`/hotspots/${w.address}`)}
-                  ></Marker>
-                </Tooltip>
-                <Layer
-                  key={'line-' + w.address}
-                  type="line"
-                  layout={{
-                    'line-cap': 'round',
-                    'line-join': 'round',
-                  }}
-                  paint={{
-                    'line-color': '#F1C40F',
-                    'line-width': 2,
-                    'line-opacity': 0.3,
-                  }}
-                >
-                  <Feature
-                    coordinates={[
-                      [w.lng, w.lat],
-                      [hotspot.lng, hotspot.lat],
-                    ]}
-                  />
-                </Layer>
-              </>
-            ))}
+            witnesses.map((w) => {
+              if (haversineDistance(hotspot?.lng, hotspot?.lat, w.lng, w.lat) <= MAX_WITNESS_DISTANCE_THRESHOLD) {
+                return (
+                  <>
+                    <Tooltip title={animalHash(w.address)}>
+                      <Marker
+                        key={w.address}
+                        style={styles.witnessMarker}
+                        anchor="center"
+                        coordinates={[w.lng, w.lat]}
+                        onClick={() => router.push(`/hotspots/${w.address}`)}
+                      ></Marker>
+                    </Tooltip>
+                    <Layer
+                      key={'line-' + w.address}
+                      type="line"
+                      layout={{
+                        'line-cap': 'round',
+                        'line-join': 'round',
+                      }}
+                      paint={{
+                        'line-color': '#F1C40F',
+                        'line-width': 2,
+                        'line-opacity': 0.3,
+                      }}
+                    >
+                      <Feature
+                        coordinates={[
+                          [w.lng, w.lat],
+                          [hotspot.lng, hotspot.lat],
+                        ]}
+                      />
+                    </Layer>
+                  </>
+                )
+              }
+            })}
         </Mapbox>
       </div>
     )

--- a/components/Hotspots/HotspotMapbox.js
+++ b/components/Hotspots/HotspotMapbox.js
@@ -77,7 +77,6 @@ const HotspotMapbox = ({
   // include witnesses in centering / zooming logic
   witnesses.map((w) => {
     const distance = haversineDistance(hotspot?.lng, hotspot?.lat, w.lng, w.lat)
-    console.log(distance);
     if (showWitnesses && distance <= MAX_WITNESS_DISTANCE_THRESHOLD) {
       boundsLocations.push({ lng: w?.lng, lat: w?.lat })
     }

--- a/components/Txns/utils.js
+++ b/components/Txns/utils.js
@@ -30,6 +30,26 @@ export const findBounds = (arrayOfLatsAndLons) => {
   }
 }
 
+export const haversineDistance = (lon1, lat1, lon2, lat2) => {
+  function toRad(x) {
+    return x * Math.PI / 180;
+  }
+
+  var R = 6371;
+
+  var x1 = lat2 - lat1;
+  var dLat = toRad(x1);
+  var x2 = lon2 - lon1;
+  var dLon = toRad(x2)
+  var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  var d = R * c;
+
+  return d;
+}
+
 const convertToUtc = (date) => addMinutes(date, date.getTimezoneOffset())
 
 export const generateFriendlyTimestampString = (txnTime) => {


### PR DESCRIPTION
https://github.com/helium/explorer/issues/250

Caps witness distance at 200km. Uses haversine distance to compute between hotspot and witness to determine if it should be rendered.

You can test this by replacing `witnesses` prop with mock data and changing the coordinates of a witness to be far away.

Expected behaviour is to just remove it from the map and to not affect the map bounds.

Current max threshold is 200km, I decided on this arbitrarily so please feel free to change it 😄 