### PR TITLE
additional small fixes to generate coverage job

### DIFF
--- a/pages/api/coverage.js
+++ b/pages/api/coverage.js
@@ -1,7 +1,7 @@
 const { getCache } = require('../../commonjs/redis')
-const { getCoverage } = require('../../commonjs/coverage')
+const { emptyCoverage } = require('../../commonjs/coverage')
 
 export default async function handler(req, res) {
-  const coverage = await getCache('coverage', getCoverage)
+  const coverage = await getCache('coverage', emptyCoverage)
   res.status(200).send(coverage)
 }


### PR DESCRIPTION
- this was missing the geocoded location attribute
- also changed the fallback value when there is no redis cache to be an empty geojson set rather than trying to actually fetch the whole thing