### PR TITLE
Update grays on error pages

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -26,7 +26,7 @@ export const HelpLink = ({ children, href, external }) => {
         <li className="text-navy-600 font-semibold w-full m-0 p-0">
           <div className="flex flex-row justify-between items-center">
             {children}
-            <ExternalLinkIcon className="h-5 w-auto text-gray-300" />
+            <ExternalLinkIcon className="h-5 w-auto text-gray-700" />
           </div>
         </li>
       </a>
@@ -38,7 +38,7 @@ export const HelpLink = ({ children, href, external }) => {
           <li className="text-navy-600 font-semibold w-full m-0 p-0">
             <div className="flex flex-row justify-between items-center">
               {children}
-              <InternalLinkIcon className="h-5 w-auto text-gray-300" />
+              <InternalLinkIcon className="h-5 w-auto text-gray-700" />
             </div>
           </li>
         </a>
@@ -68,7 +68,7 @@ const Custom404 = () => {
       </div>
       <div className="bg-bluegray-100 w-full">
         <div className="py-5 md:py-10 w-full mx-auto max-w-3xl px-2.5 sm:px-20">
-          <h3 className="text-gray-300 font-sans font-normal text-lg text-center normal-case tracking-normal pb-2">
+          <h3 className="text-gray-700 font-sans font-normal text-lg text-center normal-case tracking-normal pb-2">
             Let us know how you got here so we can fix it
           </h3>
           <HelpLinkList>
@@ -82,7 +82,7 @@ const Custom404 = () => {
               Report the issue on Discord
             </HelpLink>
           </HelpLinkList>
-          <h3 className="text-gray-300 font-sans font-normal text-lg text-center normal-case tracking-normal pt-5 pb-2">
+          <h3 className="text-gray-700 font-sans font-normal text-lg text-center normal-case tracking-normal pt-5 pb-2">
             Or try one of these links
           </h3>
           <HelpLinkList>

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -27,7 +27,7 @@ const Error = ({ statusCode, statusMessage }) => {
       </div>
       <div className="bg-bluegray-100 w-full">
         <div className="py-10 md:pt-20 w-full mx-auto max-w-3xl px-2.5 sm:px-20">
-          <h3 className="text-gray-300 font-sans font-normal text-lg text-center normal-case tracking-normal pb-2">
+          <h3 className="text-gray-700 font-sans font-normal text-lg text-center normal-case tracking-normal pb-2">
             Let us know how you got here so we can fix it
           </h3>
           <HelpLinkList>
@@ -43,7 +43,7 @@ const Error = ({ statusCode, statusMessage }) => {
               Report the issue on Discord
             </HelpLink>
           </HelpLinkList>
-          <h3 className="text-gray-300 font-sans font-normal text-lg text-center normal-case tracking-normal pt-5 pb-2">
+          <h3 className="text-gray-700 font-sans font-normal text-lg text-center normal-case tracking-normal pt-5 pb-2">
             Or try one of these links
           </h3>
           <HelpLinkList>


### PR DESCRIPTION
At some point, I inadvertently made text and icons disappear on the error pages because the tailwind.config.js file changed out from under them

This PR fixes the 404 page and the generic error page from this:
![Screen Shot 2021-04-08 at 3 23 19 PM](https://user-images.githubusercontent.com/10648471/114103871-bb438e00-987e-11eb-8963-f18beaff3af5.png)

To this:
![Screen Shot 2021-04-08 at 3 23 30 PM](https://user-images.githubusercontent.com/10648471/114103874-bbdc2480-987e-11eb-8d82-f8897c57401d.png)
