### PR TITLE
Add relay status

### DIFF
--- a/components/Hotspots/Checklist/Checklist.js
+++ b/components/Hotspots/Checklist/Checklist.js
@@ -3,6 +3,7 @@ import ChecklistCard from './ChecklistCard'
 import { Tooltip } from 'antd'
 import withBlockHeight from '../../withBlockHeight'
 import { Client } from '@helium/http'
+import classNames from 'classnames'
 
 const HotspotChecklist = ({ hotspot, witnesses, height, heightLoading }) => {
   const [activity, setActivity] = useState({})
@@ -25,7 +26,6 @@ const HotspotChecklist = ({ hotspot, witnesses, height, heightLoading }) => {
       })
       const challengerTxn = await challengerTxnList.take(1)
 
-      console.log(hotspot)
       // Get most recent challengee transaction
       const challengeeTxnList = await client.hotspot(hotspotid).activity.list({
         filterTypes: ['poc_receipts_v1'],
@@ -380,11 +380,47 @@ const HotspotChecklist = ({ hotspot, witnesses, height, heightLoading }) => {
     <div className={`${showChecklist ? 'pb-12' : 'pb-4'}`}>
       <button
         onClick={toggleShowChecklist}
-        className={`cursor-pointer text-gray-600 px-2 py-1 ml-4 bg-navy-600 rounded-full outline-none border-transparent text-xs ${
-          showChecklist ? 'mb-2' : ''
-        }`}
+        className={classNames(
+          'flex',
+          'flex-row',
+          'items-center',
+          'justify-between',
+          'w-32',
+          'cursor-pointer',
+          'text-gray-600',
+          'px-2',
+          'py-1',
+          'ml-5',
+          'bg-navy-600',
+          'rounded-full',
+          'outline-none',
+          'border-transparent',
+          'text-xs',
+          { 'mb-2': showChecklist },
+        )}
       >
         {showChecklist ? 'Hide' : 'Show'} checklist
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className={classNames(
+            'h-4',
+            'w-4',
+            'ml-1',
+            'transform duration-500',
+            'transition-all',
+            { 'rotate-180': !showChecklist },
+          )}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 15l7-7 7 7"
+          />
+        </svg>
       </button>
       {showChecklist && (
         <>

--- a/components/Hotspots/RelayPill.js
+++ b/components/Hotspots/RelayPill.js
@@ -1,0 +1,45 @@
+import { Tooltip } from 'antd'
+import classNames from 'classnames'
+
+const RelayPill = ({ className }) => {
+  return (
+    <div
+      className={classNames(
+        'flex',
+        'flex-row',
+        'items-center',
+        'justify-center',
+        'py-0.5',
+        'px-2.5',
+        'bg-navy-600',
+        'rounded-full',
+        className,
+      )}
+    >
+      <Tooltip placement="top" title={`Hotspot is being relayed`}>
+        <div className="bg-yellow-500 h-2.5 w-2.5 rounded-full" />
+      </Tooltip>
+      <Tooltip
+        placement="top"
+        title={
+          <>
+            Hotspot is being relayed which may affect mining. Go{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              rel="noreferrer"
+              href="https://intercom.help/heliumnetwork/en/articles/3207912-troubleshooting-network-connection-issues"
+            >
+              here
+            </a>{' '}
+            to learn more about opening ports for the Hotspot.
+          </>
+        }
+      >
+        <p className="text-gray-600 ml-2 mb-0">Relayed</p>
+      </Tooltip>
+    </div>
+  )
+}
+
+export default RelayPill

--- a/components/Hotspots/RelayPill.js
+++ b/components/Hotspots/RelayPill.js
@@ -3,42 +3,40 @@ import classNames from 'classnames'
 
 const RelayPill = ({ className }) => {
   return (
-    <div
-      className={classNames(
-        'flex',
-        'flex-row',
-        'items-center',
-        'justify-center',
-        'py-0.5',
-        'px-2.5',
-        'bg-navy-600',
-        'rounded-full',
-        className,
-      )}
+    <Tooltip
+      placement="top"
+      title={
+        <>
+          Hotspot is being relayed which may affect mining. Go{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            rel="noreferrer"
+            href="https://intercom.help/heliumnetwork/en/articles/3207912-troubleshooting-network-connection-issues"
+          >
+            here
+          </a>{' '}
+          to learn more about opening ports for the Hotspot.
+        </>
+      }
     >
-      <Tooltip placement="top" title={`Hotspot is being relayed`}>
-        <div className="bg-yellow-500 h-2.5 w-2.5 rounded-full" />
-      </Tooltip>
-      <Tooltip
-        placement="top"
-        title={
-          <>
-            Hotspot is being relayed which may affect mining. Go{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              rel="noreferrer"
-              href="https://intercom.help/heliumnetwork/en/articles/3207912-troubleshooting-network-connection-issues"
-            >
-              here
-            </a>{' '}
-            to learn more about opening ports for the Hotspot.
-          </>
-        }
+      <div
+        className={classNames(
+          'flex',
+          'flex-row',
+          'items-center',
+          'justify-center',
+          'py-0.5',
+          'px-2.5',
+          'bg-navy-600',
+          'rounded-full',
+          className,
+        )}
       >
+        <div className="bg-yellow-500 h-2.5 w-2.5 rounded-full" />
         <p className="text-gray-600 ml-2 mb-0">Relayed</p>
-      </Tooltip>
-    </div>
+      </div>
+    </Tooltip>
   )
 }
 

--- a/components/Hotspots/RewardScalePill.js
+++ b/components/Hotspots/RewardScalePill.js
@@ -4,13 +4,16 @@ import Hex from '../Hex'
 import { generateRewardScaleColor } from './utils'
 
 const RewardScalePill = ({ hotspot, className }) => (
-  <div
-    className={classNames(
-      'inline-flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full',
-      className,
-    )}
+  <Tooltip
+    placement="top"
+    title={`A Hotspot's own reward scale does not impact its earnings. Hotspots witnessing this Hotspot will see their rewards scaled up or down according to this Hotspot's reward scale.`}
   >
-    <Tooltip placement="top" title={`Reward scale: ${hotspot.rewardScale}`}>
+    <div
+      className={classNames(
+        'inline-flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full',
+        className,
+      )}
+    >
       <span className="flex items-center justify-center">
         <Hex
           width={10.5}
@@ -18,20 +21,14 @@ const RewardScalePill = ({ hotspot, className }) => (
           fillColor={generateRewardScaleColor(hotspot.rewardScale)}
         />
       </span>
-    </Tooltip>
-
-    <Tooltip
-      placement="top"
-      title={`A Hotspot's own reward scale does not impact its earnings. Hotspots witnessing this Hotspot will see their rewards scaled up or down according to this Hotspot's reward scale.`}
-    >
       <p className="mb-0 text-gray-600 ml-2">
         {hotspot.rewardScale.toLocaleString(undefined, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         })}
       </p>
-    </Tooltip>
-  </div>
+    </div>
+  </Tooltip>
 )
 
 export default RewardScalePill

--- a/components/Hotspots/StatusPill.js
+++ b/components/Hotspots/StatusPill.js
@@ -1,0 +1,45 @@
+import { Tooltip } from 'antd'
+import classNames from 'classnames'
+
+const StatusPill = ({ hotspot }) => {
+  const status = hotspot.status.online
+  return (
+    <div className="flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full">
+      <Tooltip placement="top" title={`Hotspot is ${status}`}>
+        <div
+          className={classNames('h-2.5', 'w-2.5', 'rounded-full', {
+            'bg-green-500': status === 'online',
+            'bg-red-400': status === 'offline',
+          })}
+        />
+      </Tooltip>
+      <Tooltip
+        placement="top"
+        title={`${
+          status === 'online' && hotspot.status.height === null
+            ? 'Beginning to sync'
+            : status === 'online' && hotspot.status.height !== null
+            ? `Syncing block ${hotspot.status?.height.toLocaleString()}. `
+            : 'Hotspot is not syncing. '
+        }${
+          status === 'online' && hotspot.status.height !== null
+            ? `Blocks remaining: ${(
+                hotspot.block - hotspot.status?.height
+              ).toLocaleString()}.`
+            : ``
+        }`}
+      >
+        <p className="text-gray-600 ml-2 mb-0">
+          {status === 'offline'
+            ? `Offline`
+            : hotspot.block - hotspot.status?.height >= 500 ||
+              hotspot.status.height === null
+            ? `Syncing`
+            : `Synced`}
+        </p>
+      </Tooltip>
+    </div>
+  )
+}
+
+export default StatusPill

--- a/components/Hotspots/StatusPill.js
+++ b/components/Hotspots/StatusPill.js
@@ -4,31 +4,29 @@ import classNames from 'classnames'
 const StatusPill = ({ hotspot }) => {
   const status = hotspot.status.online
   return (
-    <div className="flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full">
-      <Tooltip placement="top" title={`Hotspot is ${status}`}>
+    <Tooltip
+      placement="top"
+      title={`Hotspot is ${status}. ${
+        status === 'online' && hotspot.status.height === null
+          ? 'Beginning to sync'
+          : status === 'online' && hotspot.status.height !== null
+          ? `Syncing block ${hotspot.status?.height.toLocaleString()}. `
+          : 'Hotspot is not syncing. '
+      }${
+        status === 'online' && hotspot.status.height !== null
+          ? `Blocks remaining: ${(
+              hotspot.block - hotspot.status?.height
+            ).toLocaleString()}.`
+          : ``
+      }`}
+    >
+      <div className="flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full">
         <div
           className={classNames('h-2.5', 'w-2.5', 'rounded-full', {
             'bg-green-500': status === 'online',
             'bg-red-400': status === 'offline',
           })}
         />
-      </Tooltip>
-      <Tooltip
-        placement="top"
-        title={`${
-          status === 'online' && hotspot.status.height === null
-            ? 'Beginning to sync'
-            : status === 'online' && hotspot.status.height !== null
-            ? `Syncing block ${hotspot.status?.height.toLocaleString()}. `
-            : 'Hotspot is not syncing. '
-        }${
-          status === 'online' && hotspot.status.height !== null
-            ? `Blocks remaining: ${(
-                hotspot.block - hotspot.status?.height
-              ).toLocaleString()}.`
-            : ``
-        }`}
-      >
         <p className="text-gray-600 ml-2 mb-0">
           {status === 'offline'
             ? `Offline`
@@ -37,8 +35,8 @@ const StatusPill = ({ hotspot }) => {
             ? `Syncing`
             : `Synced`}
         </p>
-      </Tooltip>
-    </div>
+      </div>
+    </Tooltip>
   )
 }
 

--- a/components/Hotspots/utils.js
+++ b/components/Hotspots/utils.js
@@ -94,3 +94,11 @@ export const generateRewardScaleColor = (rewardScale) => {
     return '#E86161'
   }
 }
+
+export const isRelay = (listen_addrs) => {
+  return !!(
+    listen_addrs &&
+    listen_addrs.length > 0 &&
+    listen_addrs[0].match('p2p-circuit')
+  )
+}

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -16,6 +16,7 @@ import animalHash from 'angry-purple-tiger'
 import {
   formatHotspotName,
   formatLocation,
+  isRelay,
 } from '../../components/Hotspots/utils'
 import sumBy from 'lodash/sumBy'
 import ReactCountryFlag from 'react-country-flag'
@@ -25,6 +26,8 @@ import {
   getHotspotRewardsBuckets,
 } from '../../data/hotspots'
 import RewardScalePill from '../../components/Hotspots/RewardScalePill'
+import StatusPill from '../../components/Hotspots/StatusPill'
+import RelayPill from '../../components/Hotspots/RelayPill'
 
 const HotspotMapbox = dynamic(
   () => import('../../components/Hotspots/HotspotMapbox'),
@@ -148,56 +151,12 @@ const HotspotView = ({ hotspot }) => {
               <div className="w-full">
                 <Fade delay={500}>
                   <div className="flex flex-row items-center justify-start p-0 pb-2 w-auto">
-                    <div className="flex flex-row items-center justify-center py-0.5 px-2.5 bg-navy-600 rounded-full">
-                      <Tooltip
-                        placement="top"
-                        title={`Hotspot is ${hotspot.status.online}`}
-                      >
-                        <div
-                          className={classNames(
-                            'h-2.5',
-                            'w-2.5',
-                            'rounded-full',
-                            {
-                              'bg-green-500':
-                                hotspot.status.online === 'online',
-                              'bg-red-400': hotspot.status.online === 'offline',
-                            },
-                          )}
-                        />
-                      </Tooltip>
-                      <Tooltip
-                        placement="top"
-                        title={`${
-                          hotspot.status.online === 'online' &&
-                          hotspot.status.height === null
-                            ? 'Beginning to sync'
-                            : hotspot.status.online === 'online' &&
-                              hotspot.status.height !== null
-                            ? `Syncing block ${hotspot.status?.height.toLocaleString()}. `
-                            : 'Hotspot is not syncing. '
-                        }${
-                          hotspot.status.online === 'online' &&
-                          hotspot.status.height !== null
-                            ? `Blocks remaining: ${(
-                                hotspot.block - hotspot.status?.height
-                              ).toLocaleString()}.`
-                            : ``
-                        }`}
-                      >
-                        <p className="text-gray-600 ml-2 mb-0">
-                          {hotspot.status.online === 'offline'
-                            ? `Offline`
-                            : hotspot.block - hotspot.status?.height >= 500 ||
-                              hotspot.status.height === null
-                            ? `Syncing`
-                            : `Synced`}
-                        </p>
-                      </Tooltip>
-                    </div>
-
+                    <StatusPill hotspot={hotspot} />
                     {hotspot.rewardScale && (
                       <RewardScalePill hotspot={hotspot} className="ml-2.5" />
+                    )}
+                    {isRelay(hotspot.status.listen_addrs) && (
+                      <RelayPill className="ml-2.5" />
                     )}
                   </div>
                 </Fade>

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -145,7 +145,6 @@ const HotspotView = ({ hotspot }) => {
               </p>
             </div>
           )}
-
           <Row className="px-5 sm:px-0 pb-4 sm:pb-8">
             <div className="flex justify-start items-start pr-5">
               <div className="w-full">


### PR DESCRIPTION
Adds a relay indicator if a hotspot is being relayed. Uses the same logic from `explorer.helium.wtf/validators` to determine if it's being relayed:

![Screen Shot 2021-04-08 at 6 34 38 PM](https://user-images.githubusercontent.com/10648471/114116674-f1423b80-9899-11eb-994d-4f11b7eb4f93.png)

And this is the tooltip:
![Screen Shot 2021-04-08 at 6 42 41 PM](https://user-images.githubusercontent.com/10648471/114116893-6281ee80-989a-11eb-9e6e-bf416a3de0fb.png)

("here" is [here](https://intercom.help/heliumnetwork/en/articles/3207912-troubleshooting-network-connection-issues))

Also turned the first pill into a component called `<StatusPill />`

This can eventually be combined with the "Online" pill, like it is on the testnet validators page, but this will be good to educate people so they don't think it's a sudden change that just started happening recently.

Fixes #295 