### PR TITLE
Temporarily disable activity lists

### DIFF
--- a/pages/accounts/[accountid].js
+++ b/pages/accounts/[accountid].js
@@ -242,11 +242,16 @@ const AccountView = ({ account }) => {
           hotspots={hotspots}
         />
         <BeaconsList type="account" address={account.address} />
-        <ActivityList
+        <div className="bg-white flex items-center justify-center p-5">
+          <p className="text-gray-700 p-0 m-0">
+            Activity list is temporarily disabled
+          </p>
+        </div>{' '}
+        {/* <ActivityList
           type="account"
           address={account.address}
           hotspots={hotspots}
-        />
+        /> */}
       </Content>
     </AppLayout>
   )

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -269,7 +269,12 @@ const HotspotView = ({ hotspot }) => {
           }}
           classes="mx-auto pb-5 mt-0"
         >
-          <ActivityList type="hotspot" address={hotspot.address} />
+          {/* <ActivityList type="hotspot" address={hotspot.address} /> */}
+          <div className="bg-white flex items-center justify-center p-5">
+            <p className="text-gray-700 p-0 m-0">
+              Activity list is temporarily disabled
+            </p>
+          </div>
         </Content>
       </div>
 
@@ -287,7 +292,12 @@ const HotspotView = ({ hotspot }) => {
           }}
         >
           <TabPane tab="Activity" key="1" style={{ paddingBottom: 50 }}>
-            <ActivityList type="hotspot" address={hotspot.address} />
+            {/* <ActivityList type="hotspot" address={hotspot.address} /> */}
+            <div className="bg-white flex items-center justify-center p-5">
+              <p className="text-gray-700 p-0 m-0">
+                Activity list is temporarily disabled
+              </p>
+            </div>
           </TabPane>
           <TabPane tab="Witnesses" key="2" style={{ paddingBottom: 50 }}>
             <WitnessesList


### PR DESCRIPTION
Temporarily disables activity list on hotspot page and account page, to give the `/activity` endpoint a bit of breathing room.

I commented out the ActivityList component, and all the activity fetching is contained within that component so it should lighten the load a little bit.

Replaces it with this:
![Screen Shot 2021-04-12 at 12 53 11 PM](https://user-images.githubusercontent.com/10648471/114453127-141c6a80-9b8e-11eb-9ce4-cba8020979b6.png)