### PR TITLE
Optimize activity list

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Client from '@helium/http'
+import Client, { Network } from '@helium/http'
 import { Table, Card, Button, Tooltip, Checkbox, Typography } from 'antd'
 import { FilterOutlined } from '@ant-design/icons'
 import Timestamp from 'react-timestamp'
@@ -40,7 +40,7 @@ class ActivityList extends Component {
   state = initialState
 
   async componentDidMount() {
-    this.client = new Client()
+    this.client = new Client(Network.production, { retry: 0 })
     this.loadData()
   }
 

--- a/components/Hotspots/RewardSummary.js
+++ b/components/Hotspots/RewardSummary.js
@@ -1,7 +1,12 @@
+import { useEffect, useState } from 'react'
 import RewardSummaryCard from './RewardSummaryCard'
 import { sumBy } from 'lodash'
+import { getHotspotRewardsBuckets } from '../../data/hotspots'
 
-const RewardSummary = ({ rewards, rewardsLoading }) => {
+const RewardSummary = ({ hotspot }) => {
+  const [rewards, setRewards] = useState([])
+  const [rewardsLoading, setRewardsLoading] = useState(true)
+
   let yearBuckets = []
   if (!rewardsLoading) yearBuckets = rewards.buckets.year
 
@@ -25,6 +30,37 @@ const RewardSummary = ({ rewards, rewardsLoading }) => {
     return tempArray
   }
   // const monthBucketsForYear = splitYearIntoMonths(yearBuckets)
+
+  useEffect(() => {
+    const hotspotid = hotspot.address
+
+    async function getHotspotRewards() {
+      setRewardsLoading(true)
+      const sixtyDays = await getHotspotRewardsBuckets(hotspotid, 60, 'day')
+      const fourtyEightHours = await getHotspotRewardsBuckets(
+        hotspotid,
+        48,
+        'hour',
+      )
+      // const oneYear = await getHotspotRewardsBuckets(hotspotid, 365, 'day')
+      setRewards({
+        buckets: {
+          days: sixtyDays,
+          hours: fourtyEightHours,
+          // year: oneYear,
+        },
+        day: sumBy(sixtyDays.slice(0, 1), 'total'),
+        previousDay: sumBy(sixtyDays.slice(1, 2), 'total'),
+        week: sumBy(sixtyDays.slice(0, 7), 'total'),
+        previousWeek: sumBy(sixtyDays.slice(7, 14), 'total'),
+        month: sumBy(sixtyDays.slice(0, 30), 'total'),
+        previousMonth: sumBy(sixtyDays.slice(30, 60), 'total'),
+        // oneYear: sumBy(oneYear, 'total'),
+      })
+      setRewardsLoading(false)
+    }
+    getHotspotRewards()
+  }, [])
 
   return (
     <div

--- a/components/NearbyHotspotsList.js
+++ b/components/NearbyHotspotsList.js
@@ -62,7 +62,9 @@ const NearbyHotspotsList = ({ nearbyHotspots, nearbyHotspotsLoading }) => {
             padding: '20px',
           }}
         >
-          Hotspot has no nearby hotspots (within 2km)
+          {nearbyHotspotsLoading
+            ? 'Nearby hotspots are loading'
+            : 'Hotspot has no nearby hotspots (within 2km)'}
         </p>
       ) : (
         <span className="ant-table-styling-override">

--- a/components/WitnessesList.js
+++ b/components/WitnessesList.js
@@ -109,7 +109,9 @@ const WitnessesList = ({ witnesses, witnessesLoading }) => {
             padding: '20px',
           }}
         >
-          Hotspot has no recent witnesses
+          {witnessesLoading
+            ? 'Witnesses are loading'
+            : 'Hotspot has no recent witnesses'}
         </p>
       ) : (
         <span className="ant-table-styling-override">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@ensdomains/ensjs": "^2.0.0",
     "@helium/crypto": "^3.1.0",
     "@helium/currency": "^3.0.0",
-    "@helium/http": "^3.26.0",
+    "@helium/http": "^3.29.0",
     "@mapbox/mapbox-sdk": "^0.11.0",
     "@next/bundle-analyzer": "^10.0.6",
     "@testing-library/jest-dom": "^4.2.4",

--- a/pages/accounts/[accountid].js
+++ b/pages/accounts/[accountid].js
@@ -241,9 +241,7 @@ const AccountView = ({ account }) => {
           className=""
           defaultActiveKey="1"
           centered
-          style={{
-            background: 'white',
-          }}
+          tabBarStyle={{ margin: 0, backgroundColor: 'white' }}
         >
           <TabPane tab="Hotspots" key="1" style={{ paddingBottom: 50 }}>
             <HotspotsList

--- a/pages/accounts/[accountid].js
+++ b/pages/accounts/[accountid].js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Typography, Descriptions, Tooltip } from 'antd'
+import { Typography, Descriptions, Tooltip, Tabs } from 'antd'
 import Client from '@helium/http'
 import AppLayout, { Content } from '../../components/AppLayout'
 import ActivityList from '../../components/ActivityList'
@@ -23,6 +23,7 @@ import BeaconsList from '../../components/Beacons/BeaconsList'
 import { getMakerName } from '../../components/Makers/utils'
 
 const { Title } = Typography
+const { TabPane } = Tabs
 
 const AccountView = ({ account }) => {
   const dcBalanceObject = new Balance(
@@ -236,17 +237,32 @@ const AccountView = ({ account }) => {
           marginTop: 0,
         }}
       >
-        <HotspotsList
-          rewardsLoading={rewardsLoading}
-          hotspotsLoading={hotspotsLoading}
-          hotspots={hotspots}
-        />
-        <BeaconsList type="account" address={account.address} />
-        <ActivityList
-          type="account"
-          address={account.address}
-          hotspots={hotspots}
-        />
+        <Tabs
+          className=""
+          defaultActiveKey="1"
+          centered
+          style={{
+            background: 'white',
+          }}
+        >
+          <TabPane tab="Hotspots" key="1" style={{ paddingBottom: 50 }}>
+            <HotspotsList
+              rewardsLoading={rewardsLoading}
+              hotspotsLoading={hotspotsLoading}
+              hotspots={hotspots}
+            />
+          </TabPane>
+          <TabPane tab="Beacons" key="2" style={{ paddingBottom: 50 }}>
+            <BeaconsList type="account" address={account.address} />
+          </TabPane>
+          <TabPane tab="Activity" key="3" style={{ paddingBottom: 50 }}>
+            <ActivityList
+              type="account"
+              address={account.address}
+              hotspots={hotspots}
+            />
+          </TabPane>
+        </Tabs>
       </Content>
     </AppLayout>
   )

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -230,15 +230,6 @@ const HotspotView = ({ hotspot }) => {
           </Content>
         </div>
       </div>
-
-      <Content
-        style={{
-          maxWidth: 850,
-        }}
-        classes="mx-auto pb-5 mt-0"
-      >
-        <RewardSummary rewardsLoading={rewardsLoading} rewards={rewards} />
-      </Content>
       <Content
         style={{
           maxWidth: 850,
@@ -253,19 +244,22 @@ const HotspotView = ({ hotspot }) => {
             background: 'white',
           }}
         >
-          <TabPane tab="Witnesses" key="1" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Rewards" key="1" style={{ paddingBottom: 50 }}>
+            <RewardSummary rewardsLoading={rewardsLoading} rewards={rewards} />
+          </TabPane>
+          <TabPane tab="Witnesses" key="2" style={{ paddingBottom: 50 }}>
             <WitnessesList
               witnessesLoading={witnessesLoading}
               witnesses={witnesses}
             />
           </TabPane>
-          <TabPane tab="Nearby Hotspots" key="2" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Nearby Hotspots" key="3" style={{ paddingBottom: 50 }}>
             <NearbyHotspotsList
               nearbyHotspotsLoading={nearbyHotspotsLoading}
               nearbyHotspots={nearbyHotspots}
             />
           </TabPane>
-          <TabPane tab="Activity" key="3" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Activity" key="4" style={{ paddingBottom: 50 }}>
             <ActivityList type="hotspot" address={hotspot.address} />
           </TabPane>
         </Tabs>

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -239,7 +239,7 @@ const HotspotView = ({ hotspot }) => {
       >
         <RewardSummary rewardsLoading={rewardsLoading} rewards={rewards} />
       </Content>
-      <div className="hidden sm:block">
+      {/* <div className="hidden sm:block">
         <Content
           style={{
             maxWidth: 850,
@@ -271,35 +271,36 @@ const HotspotView = ({ hotspot }) => {
         >
           <ActivityList type="hotspot" address={hotspot.address} />
         </Content>
-      </div>
+      </div> */}
 
       <Content
         style={{
           maxWidth: 850,
         }}
-        classes="mx-auto mt-5 pb-24 block sm:hidden"
+        classes="mx-auto mt-5 pb-24 zblock zsm:hidden"
       >
         <Tabs
           className=""
+          defaultActiveKey="1"
           centered
           style={{
             background: 'white',
           }}
         >
-          <TabPane tab="Activity" key="1" style={{ paddingBottom: 50 }}>
-            <ActivityList type="hotspot" address={hotspot.address} />
-          </TabPane>
-          <TabPane tab="Witnesses" key="2" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Witnesses" key="1" style={{ paddingBottom: 50 }}>
             <WitnessesList
               witnessesLoading={witnessesLoading}
               witnesses={witnesses}
             />
           </TabPane>
-          <TabPane tab="Nearby Hotspots" key="3" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Nearby Hotspots" key="2" style={{ paddingBottom: 50 }}>
             <NearbyHotspotsList
               nearbyHotspotsLoading={nearbyHotspotsLoading}
               nearbyHotspots={nearbyHotspots}
             />
+          </TabPane>
+          <TabPane tab="Activity" key="3" style={{ paddingBottom: 50 }}>
+            <ActivityList type="hotspot" address={hotspot.address} />
           </TabPane>
         </Tabs>
       </Content>

--- a/pages/hotspots/[hotspotid].js
+++ b/pages/hotspots/[hotspotid].js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Row, Typography, Checkbox, Tooltip, Tabs } from 'antd'
+import { Row, Typography, Tooltip, Tabs } from 'antd'
 import { Client } from '@helium/http'
 import Fade from 'react-reveal/Fade'
 import Checklist from '../../components/Hotspots/Checklist/Checklist'
@@ -18,13 +18,8 @@ import {
   formatLocation,
   isRelay,
 } from '../../components/Hotspots/utils'
-import sumBy from 'lodash/sumBy'
 import ReactCountryFlag from 'react-country-flag'
-import classNames from 'classnames'
-import {
-  fetchNearbyHotspots,
-  getHotspotRewardsBuckets,
-} from '../../data/hotspots'
+import { fetchNearbyHotspots } from '../../data/hotspots'
 import RewardScalePill from '../../components/Hotspots/RewardScalePill'
 import StatusPill from '../../components/Hotspots/StatusPill'
 import RelayPill from '../../components/Hotspots/RelayPill'
@@ -42,20 +37,16 @@ const { TabPane } = Tabs
 
 const HotspotView = ({ hotspot }) => {
   const [witnesses, setWitnesses] = useState([])
-  const [rewards, setRewards] = useState([])
   const [nearbyHotspots, setNearbyHotspots] = useState([])
 
   const [witnessesLoading, setWitnessesLoading] = useState(true)
-  const [rewardsLoading, setRewardsLoading] = useState(true)
   const [nearbyHotspotsLoading, setNearbyHotspotsLoading] = useState(true)
 
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    setLoading(
-      !(!witnessesLoading && !rewardsLoading && !nearbyHotspotsLoading),
-    )
-  }, [witnessesLoading, rewardsLoading, nearbyHotspotsLoading])
+    setLoading(!(!witnessesLoading && !nearbyHotspotsLoading))
+  }, [witnessesLoading, nearbyHotspotsLoading])
 
   useEffect(() => {
     const hotspotid = hotspot.address
@@ -78,35 +69,8 @@ const HotspotView = ({ hotspot }) => {
       setNearbyHotspotsLoading(false)
     }
 
-    async function getHotspotRewards() {
-      setRewardsLoading(true)
-      const sixtyDays = await getHotspotRewardsBuckets(hotspotid, 60, 'day')
-      const fourtyEightHours = await getHotspotRewardsBuckets(
-        hotspotid,
-        48,
-        'hour',
-      )
-      // const oneYear = await getHotspotRewardsBuckets(hotspotid, 365, 'day')
-      setRewards({
-        buckets: {
-          days: sixtyDays,
-          hours: fourtyEightHours,
-          // year: oneYear,
-        },
-        day: sumBy(sixtyDays.slice(0, 1), 'total'),
-        previousDay: sumBy(sixtyDays.slice(1, 2), 'total'),
-        week: sumBy(sixtyDays.slice(0, 7), 'total'),
-        previousWeek: sumBy(sixtyDays.slice(7, 14), 'total'),
-        month: sumBy(sixtyDays.slice(0, 30), 'total'),
-        previousMonth: sumBy(sixtyDays.slice(30, 60), 'total'),
-        // oneYear: sumBy(oneYear, 'total'),
-      })
-      setRewardsLoading(false)
-    }
-
     getWitnesses()
     getNearbyHotspots()
-    getHotspotRewards()
   }, [])
 
   return (
@@ -204,7 +168,6 @@ const HotspotView = ({ hotspot }) => {
             hotspot={hotspot}
             witnesses={witnesses}
             loading={loading}
-            rewardsLoading={rewardsLoading}
             witnessesLoading={witnessesLoading}
           />
         </div>
@@ -234,30 +197,28 @@ const HotspotView = ({ hotspot }) => {
         style={{
           maxWidth: 850,
         }}
-        classes="mx-auto mt-5 pb-24"
+        classes="mx-auto mt-5 pb-10"
       >
         <Tabs
           className=""
           defaultActiveKey="1"
           centered
-          style={{
-            background: 'white',
-          }}
+          tabBarStyle={{ margin: 0, backgroundColor: 'white' }}
         >
-          <TabPane tab="Rewards" key="1" style={{ paddingBottom: 50 }}>
-            <RewardSummary rewardsLoading={rewardsLoading} rewards={rewards} />
-          </TabPane>
-          <TabPane tab="Witnesses" key="2" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Witnesses" key="1" style={{ paddingBottom: 50 }}>
             <WitnessesList
               witnessesLoading={witnessesLoading}
               witnesses={witnesses}
             />
           </TabPane>
-          <TabPane tab="Nearby Hotspots" key="3" style={{ paddingBottom: 50 }}>
+          <TabPane tab="Nearby Hotspots" key="2" style={{ paddingBottom: 50 }}>
             <NearbyHotspotsList
               nearbyHotspotsLoading={nearbyHotspotsLoading}
               nearbyHotspots={nearbyHotspots}
             />
+          </TabPane>
+          <TabPane tab="Rewards" key="3" style={{ paddingBottom: 50 }}>
+            <RewardSummary hotspot={hotspot} />
           </TabPane>
           <TabPane tab="Activity" key="4" style={{ paddingBottom: 50 }}>
             <ActivityList type="hotspot" address={hotspot.address} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,10 +1906,10 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.26.0":
-  version "3.26.0"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.26.0.tgz#ccb662034690429a5ef4b5bfed0ddacf5712b007"
-  integrity sha512-H4lNiK/IlHHYn+ZuWTlr8psKzoEZRnLN3o95/cndV7qEdHjZ9MUW1BuimOwrUYAd7qyhjZEquCM2eTBC3OZPuw==
+"@helium/http@^3.29.0":
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.29.0.tgz#87ed6e55492810fdfa23116084eb0012380755f8"
+  integrity sha512-usAfxoVqBpnVX+VMktgAj5yZz1NTDHVrR2zCwY8y9BwacWH2qZwjoohbsupqa84fThQklCagoTt6nSP340Z57A==
   dependencies:
     "@helium/currency" "^3.25.1"
     axios "^0.21.1"


### PR DESCRIPTION
This hides the activity list behind a tab pane on the hotspot and the account page. Like so:

![Screen Shot 2021-04-13 at 1 18 00 PM](https://user-images.githubusercontent.com/10648471/114615585-b99d1000-9c5a-11eb-92ca-7e6ea3e1aa2b.png)

![Screen Shot 2021-04-13 at 12 43 01 PM](https://user-images.githubusercontent.com/10648471/114611385-d551e780-9c55-11eb-9c25-0bbcae41a9cb.png)

And it won't load the data for that panel until it's active, because `forceRender` is false by default in Ant Design's `Tabs.TabePane` component, and the default behaviour is that it won't render the contents until that tab is clicked on.

This PR also makes the ActivityList component not retry to fetch data if a request fails, because the `/activity` endpoint is quite heavy so we don't want to keep hitting it when it fails.