### PR TITLE
clean up top level state

### DIFF
--- a/components/InfoBox/HotspotDetailsInfoBox.js
+++ b/components/InfoBox/HotspotDetailsInfoBox.js
@@ -1,18 +1,50 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import animalHash from 'angry-purple-tiger'
+import { useAsync } from 'react-async-hooks'
+import { useParams } from 'react-router'
 import InfoBox from './InfoBox'
 import TabNavbar from '../Nav/TabNavbar'
 import RewardsTrendWidget from '../Widgets/RewardsTrendWidget'
 import Widget from '../Widgets/Widget'
 import { useHotspotRewards } from '../../data/rewards'
+import useSelectedHotspot from '../../hooks/useSelectedHotspot'
+import { fetchHotspot } from '../../data/hotspots'
 
-const HotspotDetailsInfoBox = ({ hotspot, visible, toggleVisible }) => {
+const HotspotDetailsRoute = () => {
+  const { address } = useParams()
+
+  const { selectedHotspot: hotspot, selectHotspot } = useSelectedHotspot()
+
+  useAsync(async () => {
+    if (!hotspot) {
+      const fetchedHotspot = await fetchHotspot(address)
+      selectHotspot(fetchedHotspot)
+    }
+  }, [hotspot, address])
+
+  if (!hotspot) return null
+
+  return <HotspotDetailsInfoBox />
+}
+
+const HotspotDetailsInfoBox = () => {
+  const {
+    selectedHotspot: hotspot,
+    clearSelectedHotspot,
+  } = useSelectedHotspot()
+
   const { rewards } = useHotspotRewards(hotspot.address)
 
   const title = useMemo(() => animalHash(hotspot.address), [hotspot])
 
+  useEffect(() => {
+    return () => {
+      clearSelectedHotspot()
+    }
+  }, [clearSelectedHotspot])
+
   return (
-    <InfoBox title={title} visible={visible} toggleVisible={toggleVisible}>
+    <InfoBox title={title}>
       <div className="w-full bg-white z-10 rounded-t-xl">
         <TabNavbar />
       </div>
@@ -32,4 +64,4 @@ const HotspotDetailsInfoBox = ({ hotspot, visible, toggleVisible }) => {
   )
 }
 
-export default HotspotDetailsInfoBox
+export default HotspotDetailsRoute

--- a/components/InfoBox/HotspotsInfoBox.js
+++ b/components/InfoBox/HotspotsInfoBox.js
@@ -5,29 +5,34 @@ import Widget from '../Widgets/Widget'
 import FlagLocation from '../Common/FlagLocation'
 import PillNavbar from '../Nav/PillNavbar'
 import TabNavbar from '../Nav/TabNavbar'
+import { useHotspotsStats } from '../../data/hotspots'
 
-const HotspotsInfoBox = ({ stats, visible = true, toggleVisible }) => (
-  <InfoBox title="Hotspots" visible={visible} toggleVisible={toggleVisible}>
-    <div className="w-full bg-white z-10 rounded-t-xl">
-      <PillNavbar />
-      <TabNavbar />
-    </div>
-    <div className="grid grid-flow-row grid-cols-2 gap-3 md:gap-4 p-4 md:p-8 overflow-y-scroll">
-      <TrendWidget title="Hotspots" series={stats?.count} />
-      <StatWidget title="% Online" series={stats?.onlinePct} />
-      <StatWidget title="Hotspot Owners" series={stats?.ownersCount} />
-      <StatWidget title="Cities" series={stats?.citiesCount} />
-      <StatWidget title="Countries" series={stats?.countriesCount} />
-      <Widget
-        title="Latest Hotspot"
-        value="Rural Midnight Panda"
-        subtitle={<FlagLocation geocode={geocode} />}
-        span={2}
-      />
-      <div className="col-span-2 pb-1" />
-    </div>
-  </InfoBox>
-)
+const HotspotsInfoBox = () => {
+  const { hotspotsStats: stats } = useHotspotsStats()
+
+  return (
+    <InfoBox title="Hotspots">
+      <div className="w-full bg-white z-10 rounded-t-xl">
+        <PillNavbar />
+        <TabNavbar />
+      </div>
+      <div className="grid grid-flow-row grid-cols-2 gap-3 md:gap-4 p-4 md:p-8 overflow-y-scroll">
+        <TrendWidget title="Hotspots" series={stats?.count} />
+        <StatWidget title="% Online" series={stats?.onlinePct} />
+        <StatWidget title="Hotspot Owners" series={stats?.ownersCount} />
+        <StatWidget title="Cities" series={stats?.citiesCount} />
+        <StatWidget title="Countries" series={stats?.countriesCount} />
+        <Widget
+          title="Latest Hotspot"
+          value="Rural Midnight Panda"
+          subtitle={<FlagLocation geocode={geocode} />}
+          span={2}
+        />
+        <div className="col-span-2 pb-1" />
+      </div>
+    </InfoBox>
+  )
+}
 
 const geocode = {
   cityId: 'ZW5jaW5pdGFzY2FsaWZvcm5pYXVuaXRlZCBzdGF0ZXM',

--- a/components/InfoBox/InfoBox.js
+++ b/components/InfoBox/InfoBox.js
@@ -1,14 +1,16 @@
 import Image from 'next/image'
+import useInfoBox from '../../hooks/useInfoBox'
 
-const InfoBox = ({ title, visible = true, toggleVisible, children }) => {
+const InfoBox = ({ title, children }) => {
+  const { showInfoBox, toggleInfoBox } = useInfoBox()
   return (
     <div
       className="fixed left-0 z-20 md:left-10 md:top-0 bottom-0 md:m-auto w-full md:w-120 h-3/5 transform-gpu transition-transform duration-200 ease-in-out"
-      style={{ transform: `translateY(${visible ? 0 : 120}%)` }}
+      style={{ transform: `translateY(${showInfoBox ? 0 : 120}%)` }}
     >
       <div className="absolute flex justify-between w-full -top-16 p-4 md:px-0">
         <span className="text-white text-3xl font-semibold">{title}</span>
-        <div className="md:hidden" onClick={toggleVisible}>
+        <div className="md:hidden" onClick={toggleInfoBox}>
           <Image src="/images/circle-arrow.svg" width={35} height={35} />
         </div>
       </div>

--- a/components/InfoBox/OverviewInfoBox.js
+++ b/components/InfoBox/OverviewInfoBox.js
@@ -5,29 +5,34 @@ import Widget from '../Widgets/Widget'
 import FlagLocation from '../Common/FlagLocation'
 import PillNavbar from '../Nav/PillNavbar'
 import TabNavbar from '../Nav/TabNavbar'
+import { useHotspotsStats } from '../../data/hotspots'
 
-const OverviewInfoBox = ({ stats, visible = true, toggleVisible }) => (
-  <InfoBox title="Overview" visible={visible} toggleVisible={toggleVisible}>
-    <div className="w-full bg-white z-10 rounded-t-xl">
-      <PillNavbar />
-      <TabNavbar />
-    </div>
-    <div className="grid grid-flow-row grid-cols-2 gap-3 md:gap-4 p-4 md:p-8 overflow-y-scroll">
-      <TrendWidget title="Hotspots" series={stats?.count} />
-      <StatWidget title="% Online" series={stats?.onlinePct} />
-      <StatWidget title="Hotspot Owners" series={stats?.ownersCount} />
-      <StatWidget title="Cities" series={stats?.citiesCount} />
-      <StatWidget title="Countries" series={stats?.countriesCount} />
-      <Widget
-        title="Latest Hotspot"
-        value="Rural Midnight Panda"
-        subtitle={<FlagLocation geocode={geocode} />}
-        span={2}
-      />
-      <div className="col-span-2 pb-1" />
-    </div>
-  </InfoBox>
-)
+const OverviewInfoBox = () => {
+  const { hotspotsStats: stats } = useHotspotsStats()
+
+  return (
+    <InfoBox title="Overview">
+      <div className="w-full bg-white z-10 rounded-t-xl">
+        <PillNavbar />
+        <TabNavbar />
+      </div>
+      <div className="grid grid-flow-row grid-cols-2 gap-3 md:gap-4 p-4 md:p-8 overflow-y-scroll">
+        <TrendWidget title="Hotspots" series={stats?.count} />
+        <StatWidget title="% Online" series={stats?.onlinePct} />
+        <StatWidget title="Hotspot Owners" series={stats?.ownersCount} />
+        <StatWidget title="Cities" series={stats?.citiesCount} />
+        <StatWidget title="Countries" series={stats?.countriesCount} />
+        <Widget
+          title="Latest Hotspot"
+          value="Rural Midnight Panda"
+          subtitle={<FlagLocation geocode={geocode} />}
+          span={2}
+        />
+        <div className="col-span-2 pb-1" />
+      </div>
+    </InfoBox>
+  )
+}
 
 const geocode = {
   cityId: 'ZW5jaW5pdGFzY2FsaWZvcm5pYXVuaXRlZCBzdGF0ZXM',

--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -6,6 +6,10 @@ import { useAsync } from 'react-async-hooks'
 import { findBounds } from '../../utils/location'
 import CoverageLayer from './Layers/CoverageLayer'
 import HotspotDetailLayer from './Layers/HotspotDetailLayer'
+import useSelectedHotspot from '../../hooks/useSelectedHotspot'
+import useMapLayer from '../../hooks/useMapLayer'
+import useInfoBox from '../../hooks/useInfoBox'
+import useGeolocation from '../../hooks/useGeolocation'
 
 const maxZoom = 14
 const minZoom = 2
@@ -38,15 +42,14 @@ const EU_CN_BOUNDS = [
 const MOBILE_PADDING = { top: 10, left: 10, right: 10, bottom: 450 }
 const DESKTOP_PADDING = { top: 10, left: 600, right: 10, bottom: 10 }
 
-const CoverageMap = ({
-  currentPosition = initialPosition,
-  selectedHotspot,
-  selectHotspot,
-  showInfoBox,
-  layer,
-}) => {
+const CoverageMap = () => {
   const isDesktopOrLaptop = useMediaQuery({ minDeviceWidth: 1224 })
   const map = useRef()
+
+  const { showInfoBox } = useInfoBox()
+  const { mapLayer } = useMapLayer()
+  const { selectHotspot, selectedHotspot } = useSelectedHotspot()
+  const { currentPosition } = useGeolocation()
 
   const [coverage, setCoverage] = useState()
   const [bounds, setBounds] = useState(
@@ -154,7 +157,7 @@ const CoverageMap = ({
         minZoom={minZoom}
         maxZoom={maxZoom}
         onHotspotClick={handleHotspotClick}
-        layer={layer}
+        layer={mapLayer}
       />
       <HotspotDetailLayer hotspot={selectedHotspot} />
     </Mapbox>

--- a/components/Map/MapControls.js
+++ b/components/Map/MapControls.js
@@ -1,19 +1,22 @@
 import classNames from 'classnames'
 import Image from 'next/image'
 import { useCallback } from 'react'
+import useGeolocation from '../../hooks/useGeolocation'
+import useInfoBox from '../../hooks/useInfoBox'
+import useMapLayer from '../../hooks/useMapLayer'
 
-const MapControls = ({
-  showInfoBox,
-  toggleShowInfoBox,
-  showMapLayers,
-  toggleShowMapLayers,
-  requestCurrentPosition,
-  loadingCurrentPosition,
-}) => {
+const MapControls = () => {
+  const { toggleInfoBox } = useInfoBox()
+  const { showMapLayers, toggleMapLayers } = useMapLayer()
+  const {
+    isLoading: isLoadingCurrentPosition,
+    requestCurrentPosition,
+  } = useGeolocation()
+
   const handleLocationClick = useCallback(() => {
-    if (loadingCurrentPosition) return
+    if (isLoadingCurrentPosition) return
     requestCurrentPosition()
-  }, [loadingCurrentPosition, requestCurrentPosition])
+  }, [isLoadingCurrentPosition, requestCurrentPosition])
 
   return (
     <div
@@ -26,7 +29,7 @@ const MapControls = ({
     >
       <div
         className="cursor-pointer md:hidden bg-navy-400 w-10 h-10 rounded-full flex items-center justify-center shadow-md"
-        onClick={toggleShowInfoBox}
+        onClick={toggleInfoBox}
       >
         <Image
           src="/images/arrow.svg"
@@ -37,7 +40,7 @@ const MapControls = ({
       </div>
       <div
         className="cursor-pointer bg-white w-10 h-10 rounded-full flex items-center justify-center shadow-md"
-        onClick={toggleShowMapLayers}
+        onClick={toggleMapLayers}
       >
         <Image src="/images/layer.svg" width={20} height={20} />
       </div>
@@ -45,7 +48,7 @@ const MapControls = ({
         className="cursor-pointer bg-white w-10 h-10 rounded-full flex items-center justify-center shadow-md"
         onClick={handleLocationClick}
       >
-        {loadingCurrentPosition ? (
+        {isLoadingCurrentPosition ? (
           <Spinner />
         ) : (
           <Image src="/images/location.svg" width={20} height={20} />

--- a/components/Map/MapLayersBox.js
+++ b/components/Map/MapLayersBox.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import Image from 'next/image'
 import { useCallback } from 'react'
+import useMapLayer from '../../hooks/useMapLayer'
 
 const Layer = ({ title, onClick, active = false }) => (
   <div className="flex flex-col items-center cursor-pointer" onClick={onClick}>
@@ -16,22 +17,24 @@ const Layer = ({ title, onClick, active = false }) => (
   </div>
 )
 
-const MapLayersBox = ({
-  showMapLayers,
-  toggleShowMapLayers,
-  layer,
-  setLayer,
-}) => {
+const MapLayersBox = () => {
+  const {
+    showMapLayers,
+    setMapLayer,
+    mapLayer,
+    toggleMapLayers,
+  } = useMapLayer()
+
   const handleClick = useCallback(
     (clickedLayer) => () => {
-      if (layer === clickedLayer) {
-        setLayer(null)
+      if (mapLayer === clickedLayer) {
+        setMapLayer(null)
         return
       }
 
-      setLayer(clickedLayer)
+      setMapLayer(clickedLayer)
     },
-    [layer, setLayer],
+    [mapLayer, setMapLayer],
   )
 
   return (
@@ -46,7 +49,7 @@ const MapLayersBox = ({
       <div className="absolute flex justify-end w-full -top-14 left-0 px-4 md:px-0">
         <div
           className="md:hidden transform rotate-180"
-          onClick={toggleShowMapLayers}
+          onClick={toggleMapLayers}
         >
           <Image src="/images/circle-arrow.svg" width={35} height={35} />
         </div>
@@ -56,22 +59,22 @@ const MapLayersBox = ({
         <Layer
           title="New Hotspots"
           onClick={handleClick('added')}
-          active={layer === 'added'}
+          active={mapLayer === 'added'}
         />
         <Layer
           title="Reward Scales"
           onClick={handleClick('rewardScale')}
-          active={layer === 'rewardScale'}
+          active={mapLayer === 'rewardScale'}
         />
         <Layer
           title="Owner"
           onClick={handleClick('owner')}
-          active={layer === 'owner'}
+          active={mapLayer === 'owner'}
         />
         <Layer
           title="Offline"
           onClick={handleClick('offline')}
-          active={layer === 'offline'}
+          active={mapLayer === 'offline'}
         />
       </div>
     </div>

--- a/hooks/useGeolocation.js
+++ b/hooks/useGeolocation.js
@@ -1,0 +1,34 @@
+import { useCallback, useContext } from 'react'
+import {
+  store,
+  SET_CURRENT_POSITION,
+  SET_CURRENT_POSITION_LOADING,
+} from '../store/store'
+import useDispatch from '../store/useDispatch'
+
+const useGeolocation = () => {
+  const dispatch = useDispatch()
+
+  const {
+    state: {
+      geolocation: { currentPosition, isLoading },
+    },
+  } = useContext(store)
+
+  const requestCurrentPosition = useCallback(() => {
+    dispatch({ type: SET_CURRENT_POSITION_LOADING })
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        dispatch({ type: SET_CURRENT_POSITION, payload: position })
+      },
+      (error) => {
+        console.error(error)
+        dispatch({ type: SET_CURRENT_POSITION_LOADING, payload: false })
+      },
+    )
+  }, [dispatch])
+
+  return { currentPosition, isLoading, requestCurrentPosition }
+}
+
+export default useGeolocation

--- a/hooks/useInfoBox.js
+++ b/hooks/useInfoBox.js
@@ -1,0 +1,19 @@
+import { useCallback, useContext } from 'react'
+import { store, TOGGLE_INFO_BOX } from '../store/store'
+import useDispatch from '../store/useDispatch'
+
+const useInfoBox = () => {
+  const dispatch = useDispatch()
+
+  const {
+    state: { showInfoBox },
+  } = useContext(store)
+
+  const toggleInfoBox = useCallback(() => {
+    dispatch({ type: TOGGLE_INFO_BOX })
+  }, [dispatch])
+
+  return { showInfoBox, toggleInfoBox }
+}
+
+export default useInfoBox

--- a/hooks/useMapLayer.js
+++ b/hooks/useMapLayer.js
@@ -1,0 +1,26 @@
+import { useCallback, useContext } from 'react'
+import { SET_MAP_LAYER, store, TOGGLE_MAP_LAYERS } from '../store/store'
+import useDispatch from '../store/useDispatch'
+
+const useMapLayer = () => {
+  const dispatch = useDispatch()
+
+  const {
+    state: { showMapLayers, mapLayer },
+  } = useContext(store)
+
+  const toggleMapLayers = useCallback(() => {
+    dispatch({ type: TOGGLE_MAP_LAYERS })
+  }, [dispatch])
+
+  const setMapLayer = useCallback(
+    (layer) => {
+      dispatch({ type: SET_MAP_LAYER, payload: layer })
+    },
+    [dispatch],
+  )
+
+  return { showMapLayers, toggleMapLayers, setMapLayer, mapLayer }
+}
+
+export default useMapLayer

--- a/hooks/useSelectedHotspot.js
+++ b/hooks/useSelectedHotspot.js
@@ -1,0 +1,51 @@
+import { useContext, useCallback } from 'react'
+import { useHistory } from 'react-router'
+import { store, SET_SELECTED_HOTSPOT } from '../store/store'
+import useDispatch from '../store/useDispatch'
+import { haversineDistance } from '../utils/location'
+
+const MAX_WITNESS_DISTANCE_THRESHOLD = 200
+
+async function getWitnesses(hotspotid) {
+  const witnesses = await fetch(
+    `https://api.helium.io/v1/hotspots/${hotspotid}/witnesses`,
+  )
+    .then((res) => res.json())
+    .then((json) => json.data.filter((w) => !(w.address === hotspotid)))
+  return witnesses
+}
+
+const useSelectedHotspot = () => {
+  const dispatch = useDispatch()
+  const history = useHistory()
+
+  const {
+    state: { selectedHotspot },
+  } = useContext(store)
+
+  const selectHotspot = useCallback(
+    async (hotspot) => {
+      const fetchedWitnesses = await getWitnesses(hotspot.address)
+      const filteredWitnesses = fetchedWitnesses.filter(
+        (w) =>
+          haversineDistance(hotspot?.lng, hotspot?.lat, w.lng, w.lat) <=
+          MAX_WITNESS_DISTANCE_THRESHOLD,
+      )
+      dispatch({
+        type: SET_SELECTED_HOTSPOT,
+        payload: { ...hotspot, witnesses: filteredWitnesses },
+      })
+      // setShowInfoBox(true)
+      history.push(`/hotspots/${hotspot.address}`)
+    },
+    [dispatch, history],
+  )
+
+  const clearSelectedHotspot = useCallback(() => {
+    dispatch({ type: SET_SELECTED_HOTSPOT, payload: null })
+  }, [dispatch])
+
+  return { selectedHotspot, selectHotspot, clearSelectedHotspot }
+}
+
+export default useSelectedHotspot

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@turf/distance": "^6.3.0",
     "@turf/helpers": "^6.3.0",
+    "@welldone-software/why-did-you-render": "^6.1.1",
     "@zeit/next-css": "^1.0.1",
     "algoliasearch": "^4.5.1",
     "angry-purple-tiger": "1.0.5",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import '../wdyr'
 import withGA from 'next-ga'
 import { BrowserRouter as Router } from 'react-router-dom'
 
@@ -6,6 +7,7 @@ import '../styles/Explorer.css'
 
 import NProgress from 'nprogress' //nprogress module
 import 'nprogress/nprogress.css' //styles of nprogress
+import { StateProvider } from '../store/store'
 
 //Binding events.
 // Router.events.on('routeChangeStart', () => NProgress.start())
@@ -18,7 +20,9 @@ function MyApp({ Component, pageProps }) {
     <div id="app" suppressHydrationWarning>
       {typeof window === 'undefined' ? null : (
         <Router>
-          <Component {...pageProps} />
+          <StateProvider>
+            <Component {...pageProps} />
+          </StateProvider>
         </Router>
       )}
       <script src="https://0m1ljfvm0g6j.statuspage.io/embed/script.js"></script>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,85 +1,21 @@
 import React, { useCallback, useState } from 'react'
-import { Switch, Route, useHistory, useRouteMatch } from 'react-router-dom'
+import { Switch, Route } from 'react-router-dom'
 import dynamic from 'next/dynamic'
 import Header from '../components/Nav/Header'
 import Page from '../components/CoverageMap/Page'
 import MetaTags from '../components/AppLayout/MetaTags'
-import useToggle from '../utils/useToggle'
 import MapLayersBox from '../components/Map/MapLayersBox'
 import MapControls from '../components/Map/MapControls'
-import { haversineDistance } from '../utils/location'
-import { useHotspotsStats } from '../data/hotspots'
 import OverviewInfoBox from '../components/InfoBox/OverviewInfoBox'
 import HotspotsInfoBox from '../components/InfoBox/HotspotsInfoBox'
 import HotspotDetailsInfoBox from '../components/InfoBox/HotspotDetailsInfoBox'
-
-const MAX_WITNESS_DISTANCE_THRESHOLD = 200
 
 const Map = dynamic(() => import('../components/Map/Map'), {
   ssr: false,
   loading: () => <div />,
 })
 
-async function getWitnesses(hotspotid) {
-  const witnesses = await fetch(
-    `https://api.helium.io/v1/hotspots/${hotspotid}/witnesses`,
-  )
-    .then((res) => res.json())
-    .then((json) => json.data.filter((w) => !(w.address === hotspotid)))
-  return witnesses
-}
-
-const Coverage = () => {
-  const history = useHistory()
-  const matchHotspotDetails = useRouteMatch('/hotspots/:address')
-
-  const [showInfoBox, toggleShowInfoBox, setShowInfoBox] = useToggle(true)
-  const [showMapLayers, toggleShowMapLayers, setShowMapLayers] = useToggle(
-    false,
-  )
-  const [currentPosition, setCurrentPosition] = useState()
-  const [loadingCurrentPosition, setLoadingCurrentPosition] = useState(false)
-  const [selectedHotspot, setSelectedHotspot] = useState()
-  const [layer, setLayer] = useState(null)
-  const { hotspotsStats } = useHotspotsStats()
-
-  const requestCurrentPosition = useCallback(() => {
-    setLoadingCurrentPosition(true)
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setCurrentPosition(position)
-        setLoadingCurrentPosition(false)
-      },
-      (error) => {
-        console.error(error)
-        setLoadingCurrentPosition(false)
-      },
-    )
-  }, [])
-
-  const handleSelectHotspot = useCallback(
-    async (hotspot) => {
-      const fetchedWitnesses = await getWitnesses(hotspot.address)
-      const filteredWitnesses = fetchedWitnesses.filter(
-        (w) =>
-          haversineDistance(hotspot?.lng, hotspot?.lat, w.lng, w.lat) <=
-          MAX_WITNESS_DISTANCE_THRESHOLD,
-      )
-      setSelectedHotspot({ ...hotspot, witnesses: filteredWitnesses })
-      setShowInfoBox(true)
-      history.push(`/hotspots/${hotspot.address}`)
-    },
-    [history, setShowInfoBox],
-  )
-
-  const handleSelectLayer = useCallback(
-    (layer) => {
-      setLayer(layer)
-      setShowMapLayers(false)
-    },
-    [setShowMapLayers],
-  )
-
+const Index = () => {
   return (
     <Page className="overflow-hidden">
       <MetaTags
@@ -92,52 +28,20 @@ const Coverage = () => {
       />
       <title>Helium Network - Coverage</title>
       <Header activeNav="coverage" />
-      <Map
-        currentPosition={currentPosition}
-        selectedHotspot={matchHotspotDetails ? selectedHotspot : undefined}
-        selectHotspot={handleSelectHotspot}
-        showInfoBox={showInfoBox}
-        layer={layer}
-      />
+      <Map />
       <Switch>
         <Route path="/hotspots/:address">
-          <HotspotDetailsInfoBox
-            hotspot={selectedHotspot}
-            visible={showInfoBox}
-            toggleVisible={toggleShowInfoBox}
-          />
+          <HotspotDetailsInfoBox />
         </Route>
         <Route path="/hotspots">
-          <HotspotsInfoBox
-            stats={hotspotsStats}
-            visible={showInfoBox}
-            toggleVisible={toggleShowInfoBox}
-          />
+          <HotspotsInfoBox />
         </Route>
         <Route path="/">
-          <OverviewInfoBox
-            stats={hotspotsStats}
-            visible={showInfoBox}
-            toggleVisible={toggleShowInfoBox}
-          />
+          <OverviewInfoBox />
         </Route>
       </Switch>
-      <MapLayersBox
-        showInfoBox={showInfoBox}
-        toggleShowInfoBox={toggleShowInfoBox}
-        showMapLayers={showMapLayers}
-        toggleShowMapLayers={toggleShowMapLayers}
-        layer={layer}
-        setLayer={handleSelectLayer}
-      />
-      <MapControls
-        showInfoBox={showInfoBox}
-        toggleShowInfoBox={toggleShowInfoBox}
-        showMapLayers={showMapLayers}
-        toggleShowMapLayers={toggleShowMapLayers}
-        requestCurrentPosition={requestCurrentPosition}
-        loadingCurrentPosition={loadingCurrentPosition}
-      />
+      <MapLayersBox />
+      <MapControls />
 
       <style jsx global>{`
         #__next,
@@ -155,4 +59,4 @@ const Coverage = () => {
   )
 }
 
-export default Coverage
+export default Index

--- a/store/store.js
+++ b/store/store.js
@@ -1,0 +1,57 @@
+import { createContext, useReducer } from 'react'
+
+const initialState = {
+  showInfoBox: true,
+  showMapLayers: false,
+  mapLayer: null,
+  selectedHotspot: null,
+  geolocation: {
+    currentPosition: { timestamp: 0 },
+    isLoading: false,
+  },
+}
+
+const store = createContext(initialState)
+const { Provider } = store
+
+export const TOGGLE_INFO_BOX = 'TOGGLE_INFO_BOX'
+export const TOGGLE_MAP_LAYERS = 'TOGGLE_MAP_LAYERS'
+export const SET_MAP_LAYER = 'SET_MAP_LAYER'
+export const SET_SELECTED_HOTSPOT = 'SET_SELECTED_HOTSPOT'
+export const SET_CURRENT_POSITION_LOADING = 'SET_CURRENT_POSITION_LOADING'
+export const SET_CURRENT_POSITION = 'SET_CURRENT_POSITION'
+
+const StateProvider = ({ children }) => {
+  const [state, dispatch] = useReducer((state, action) => {
+    console.log(action)
+    switch (action.type) {
+      case TOGGLE_INFO_BOX:
+        return { ...state, showInfoBox: !state.showInfoBox }
+      case TOGGLE_MAP_LAYERS:
+        return { ...state, showMapLayers: !state.showMapLayers }
+      case SET_MAP_LAYER:
+        return { ...state, showMapLayers: false, mapLayer: action.payload }
+      case SET_SELECTED_HOTSPOT:
+        return { ...state, selectedHotspot: action.payload }
+      case SET_CURRENT_POSITION_LOADING:
+        return {
+          ...state,
+          geolocation: {
+            ...state.geolocation,
+            isLoading: action.payload || true,
+          },
+        }
+      case SET_CURRENT_POSITION:
+        return {
+          ...state,
+          geolocation: { currentPosition: action.payload, isLoading: false },
+        }
+      default:
+        throw new Error()
+    }
+  }, initialState)
+
+  return <Provider value={{ state, dispatch }}>{children}</Provider>
+}
+
+export { store, StateProvider }

--- a/store/useDispatch.js
+++ b/store/useDispatch.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { store } from './store'
+
+const useDispatch = () => {
+  const { dispatch } = useContext(store)
+
+  return dispatch
+}
+
+export default useDispatch

--- a/wdyr.js
+++ b/wdyr.js
@@ -1,0 +1,27 @@
+/**
+ * WDYR (why-did-you-render) helps locate unnecessary re-renders.
+ * Applied in development environment, on the frontend only.
+ *
+ * It will only log unnecessary re-renders, not expected re-renders.
+ *
+ * @see https://github.com/welldone-software/why-did-you-render
+ * @see https://github.com/vercel/next.js/tree/canary/examples/with-why-did-you-render
+ */
+import React from 'react'
+
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+  const whyDidYouRender = require('@welldone-software/why-did-you-render')
+
+  // eslint-disable-next-line no-console
+  console.debug(
+    'Applying whyDidYouRender, to help you locate unnecessary re-renders during development. See https://github.com/welldone-software/why-did-you-render',
+  )
+
+  // See https://github.com/welldone-software/why-did-you-render#options
+  whyDidYouRender(React, {
+    trackAllPureComponents: true,
+    trackHooks: true,
+    logOwnerReasons: true,
+    collapseGroups: true,
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3036,6 +3036,13 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@welldone-software/why-did-you-render@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-6.1.1.tgz#3dcf66620fcafbf79e5260bd6ace5e51254055ac"
+  integrity sha512-BMFp33T4MC27qvCWsI1SqwZCxIlxoQXsPQFdGLDsPSg7sgoWX4Gzj0+hlKVrWrCBiIxi7gP2JcS9IK6CZzk8mg==
+  dependencies:
+    lodash "^4"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -9703,7 +9710,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
the strategy I came up with is to:

1) continue using swr for data fetching. it has nice features to keep data up-to-date and prevent duplicate api calls
2) use the new built-in reducer and context hooks to create a top level app state for things like toggling UI visibility and selecting items like hotspots. we then abstract the state dispatching behind custom hooks that make it really easy to use that part of the state in any component.

Ideally the app-state won't get super large since it's pretty limited in the scope of what it's used for