### PR TITLE
Temporarily use staging API to let /beacons build

### DIFF
--- a/data/beacons.js
+++ b/data/beacons.js
@@ -1,8 +1,8 @@
 import useSWR from 'swr'
-import Client from '@helium/http'
+import Client, { Network } from '@helium/http'
 
 export const fetchLatestBeacons = (count = 100) => async () => {
-  const client = new Client()
+  const client = new Client(Network.staging)
   const beacons = await (await client.challenges.list()).take(count)
 
   return JSON.parse(JSON.stringify(beacons))

--- a/pages/beacons/index.js
+++ b/pages/beacons/index.js
@@ -57,7 +57,7 @@ export async function getStaticProps() {
     props: {
       latestBeacons,
     },
-    revalidate: 10,
+    revalidate: 30,
   }
 }
 


### PR DESCRIPTION
New builds keep failing on /beacons in particular, so I'm switching it to use the staging API temporarily so we can get new features deployed more easily. I also upped the `getStaticProps` revalidate time to 30 seconds instead of 10.