### PR TITLE
Add thousands separators for block height

### DIFF
--- a/components/ActivityList.js
+++ b/components/ActivityList.js
@@ -552,7 +552,7 @@ const columns = (ownerAddress) => {
       key: 'height',
       render: (height) => (
         <Link href={`/blocks/${height}`} prefetch={false}>
-          <a>{height}</a>
+          <a>{height.toLocaleString()}</a>
         </Link>
       ),
     },

--- a/pages/txns/[txnid].js
+++ b/pages/txns/[txnid].js
@@ -226,7 +226,7 @@ const TxnView = ({ txn }) => {
                 />
 
                 <Link href={'/blocks/' + txn.height}>
-                  <a>{txn.height}</a>
+                  <a>{txn.height.toLocaleString()}</a>
                 </Link>
               </p>
               {(txn.type === 'rewards_v1' || txn.type === 'rewards_v2') && (


### PR DESCRIPTION
Fixes https://github.com/helium/explorer/issues/304

Add thousands separator for block height in two locations:
  1. On transactions page
      - <img width="100" alt="Screen Shot 2021-04-20 at 5 30 58 PM" src="https://user-images.githubusercontent.com/3699047/115467650-d956aa00-a1ff-11eb-94d7-56e4e3d4494e.png">

  2. In the block height column of the activity list
      - <img width="122" alt="Screen Shot 2021-04-20 at 5 36 07 PM" src="https://user-images.githubusercontent.com/3699047/115467694-eb384d00-a1ff-11eb-9885-a8b003e2aff5.png">


I also searched the codebase for other instances of `block.height` and `height` and couldn't find another instance that didn't have `.toLocaleString()`.
