### PR TITLE
Display state channel ID on closed state channels

### DIFF
--- a/components/Txns/StateChannelCloseV1.js
+++ b/components/Txns/StateChannelCloseV1.js
@@ -137,6 +137,9 @@ class StateChannelCloseV1 extends Component {
           <Descriptions.Item label="Number of Hotspots" span={3}>
             {totalHotspots.toLocaleString()}
           </Descriptions.Item>
+          <Descriptions.Item label="State Channel ID" span={3}>
+              {txn.stateChannel.id}
+          </Descriptions.Item>
           <Descriptions.Item label="State Channel Closer" span={3}>
             <Link href={'/accounts/' + txn.closer}>
               <a>{txn.closer}</a>


### PR DESCRIPTION
Fixes https://github.com/helium/explorer/issues/227

<img width="1144" alt="Screen Shot 2021-04-20 at 8 22 41 PM" src="https://user-images.githubusercontent.com/3699047/115479423-5f7deb00-a216-11eb-91f0-d0e0ba1ddc17.png">

@lthiery is this what you had in mind? I'm open to any feedback you may have on how to improve this PR!