### PR TITLE
Different favicon for dev mode

### DIFF
--- a/components/AppLayout/MetaTags.js
+++ b/components/AppLayout/MetaTags.js
@@ -18,12 +18,18 @@ const MetaTags = ({
     : 'https://explorer.helium.com/images/og/explorer.png'
   const metaUrl = url ? url : 'https://explorer.helium.com'
 
+  // Help developers differentiate between dev & prod by displaying the React
+  // logo in dev
+  const faviconSrc = process.env.NODE_ENV === 'production'
+  ? 'favicon.ico'
+  : 'logo.svg'
+
   return (
     <>
       <Head>
         {/* General Meta Tags */}
         <meta charSet="utf-8" />
-        <link rel="icon" href="https://explorer.helium.com/favicon.ico" />
+        <link rel="icon" href={`https://explorer.helium.com/${faviconSrc}`} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <link


### PR DESCRIPTION
Fixes https://github.com/helium/explorer/issues/117

I choose the React logo b/c it was already present in `/public` and many developers may be familiar with this logo because it's used by default when setting up a new React app with something like `create-react-app`. I'm happy to change the dev favicon to something else if reviewers have suggestions!

<img width="450" alt="Screen Shot 2021-04-20 at 8 43 13 PM" src="https://user-images.githubusercontent.com/3699047/115480893-73771c00-a219-11eb-86b8-dc5f8bd16120.png">

Left: production
Right: dev