### PR TITLE
Rename Discord server #explorer-dev to #explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code that powers the official [Helium Blockchain Explorer](https://explorer.heli
 Any and all contributions from the community are encouraged.
 
 - Guidelines for how to contribute to this repository [are here](https://github.com/helium/explorer/blob/master/CONTRIBUTING.md).
-- Discussion about the development and usage of the Helium Blockchain Explorer takes place in the [official Helium Discord Server](https://discord.gg/helium), specifically in the `#explorer-dev` channel. Join us!
+- Discussion about the development and usage of the Helium Blockchain Explorer takes place in the [official Helium Discord Server](https://discord.gg/helium), specifically in the `#explorer` channel. Join us!
 - For a list of issues and prioritization, please go to our [Project page](https://github.com/orgs/helium/projects/9).
 
 ## Getting Started


### PR DESCRIPTION
I couldn't find a `#explorer-dev` discord channel but I did find the `#explorer` channel. Was `#explorer-dev` deprecated in favor of `#explorer`?