### PR TITLE
Rename Discord server #explorer-dev to #explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The syntax takes some getting used to, and sometimes the class names can start t
 
 ## Questions
 
-If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the `#explorer-dev` channel in [the official Helium Community Discord server](http://discord.gg/helium)!
+If you run into any issues or you have any questions about how to get started contributing, feel free to reach out on the `#explorer` channel in [the official Helium Community Discord server](http://discord.gg/helium)!
 
 ## Learn More
 


### PR DESCRIPTION
Sorry, I just finished reading the README and found another instance of this deprecated Discord channel name.