### PR TITLE
Combines Assert Location V1 & V2 totals together.

### DIFF
--- a/components/Makers/utils.js
+++ b/components/Makers/utils.js
@@ -47,10 +47,12 @@ export const getMakersData = async () => {
 
       if (maker.address !== DEPRECATED_HELIUM_BURN_ADDR) {
         const txnCountsRes = await fetch(
-          `https://api.helium.io/v1/accounts/${maker.address}/activity/count?filter_types=add_gateway_v1,assert_location_v1,token_burn_v1`,
+          `https://api.helium.io/v1/accounts/${maker.address}/activity/count?filter_types=add_gateway_v1,assert_location_v1,assert_location_v2,token_burn_v1`,
         )
         const txnCounts = await txnCountsRes.json()
-        assertLocationTxns = txnCounts.data['assert_location_v1']
+        assertLocationTxns =
+          txnCounts.data['assert_location_v1'] +
+          txnCounts.data['assert_location_v2']
         addGatewayTxns = txnCounts.data['add_gateway_v1']
 
         makerTxns = {


### PR DESCRIPTION
Fixes issue #360 by requesting both V1 & V2 asserts and combining the total together.

Before Totals from public explorer:

![Screenshot from 2021-05-01 22-21-44](https://user-images.githubusercontent.com/1104745/116795350-3a1d9680-aacc-11eb-9bd5-181aa2be4717.png)


And after running on local dev:
![Screenshot from 2021-05-01 22-25-22](https://user-images.githubusercontent.com/1104745/116795336-25410300-aacc-11eb-92e7-85b353018ba9.png)
