### PR TITLE
CSV fixes for maker-paid fees & assert_location_v2

### DIFF
--- a/components/ExportCSV/ExportModal.js
+++ b/components/ExportCSV/ExportModal.js
@@ -111,7 +111,6 @@ class ExportModal extends React.Component {
     const csvExporter = new ExportToCsv(options)
 
     if (data.length) {
-      console.log(data)
       csvExporter.generateCsv(data)
     } else {
       notification.info({

--- a/components/ExportCSV/ExportModal.js
+++ b/components/ExportCSV/ExportModal.js
@@ -57,9 +57,9 @@ class ExportModal extends React.Component {
     if (txn.includes('payment')) filterTypes.push('payment_v1', 'payment_v2')
     if (txn.includes('reward')) filterTypes.push('rewards_v1', 'rewards_v2')
     if (txn.includes('transfer')) filterTypes.push('transfer_hotspot_v1')
-    if (txn.includes('assert')) filterTypes.push('assert_location_v1')
+    if (txn.includes('assert'))
+      filterTypes.push('assert_location_v1', 'assert_location_v2')
     if (txn.includes('add')) filterTypes.push('add_gateway_v1')
-
     let service = null
     let list
 
@@ -111,6 +111,7 @@ class ExportModal extends React.Component {
     const csvExporter = new ExportToCsv(options)
 
     if (data.length) {
+      console.log(data)
       csvExporter.generateCsv(data)
     } else {
       notification.info({

--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -130,12 +130,12 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
       }
     }
     case 'add_gateway_v1': {
-      const paidByUser = txn.owner === txn.payer
+      const paidByHotspotOwner = txn.owner === txn.payer
       // the above logic check could also be done by using:
       // !(await isMakerAddress(txn.payer))
       // but this seems more efficient for now
       return {
-        'Sent Quantity': paidByUser
+        'Sent Quantity': paidByHotspotOwner
           ? await getFee(
               {
                 height: txn.height,
@@ -144,18 +144,18 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
               opts.convertFee,
             )
           : 0,
-        'Sent To': paidByUser ? 'Helium Network' : '',
+        'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
         Tag: `add gateway payment (paid by ${
-          paidByUser ? 'user' : await getMakerName(txn.payer)
+          paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
-        feePaid: paidByUser,
+        feePaid: paidByHotspotOwner,
       }
     }
     case 'assert_location_v1': {
-      const paidByUser = txn.owner === txn.payer
+      const paidByHotspotOwner = txn.owner === txn.payer
       return {
-        'Sent Quantity': paidByUser
+        'Sent Quantity': paidByHotspotOwner
           ? await getFee(
               {
                 height: txn.height,
@@ -164,18 +164,18 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
               opts.convertFee,
             )
           : 0,
-        'Sent To': paidByUser ? 'Helium Network' : '',
+        'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
         Tag: `assert location payment (paid by ${
-          paidByUser ? 'user' : await getMakerName(txn.payer)
+          paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
-        feePaid: paidByUser,
+        feePaid: paidByHotspotOwner,
       }
     }
     case 'assert_location_v2': {
-      const paidByUser = txn.owner === txn.payer
+      const paidByHotspotOwner = txn.owner === txn.payer
       return {
-        'Sent Quantity': paidByUser
+        'Sent Quantity': paidByHotspotOwner
           ? await getFee(
               {
                 height: txn.height,
@@ -184,12 +184,12 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
               opts.convertFee,
             )
           : 0,
-        'Sent To': paidByUser ? 'Helium Network' : '',
+        'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
         Tag: `assert location payment (paid by ${
-          paidByUser ? 'user' : await getMakerName(txn.payer)
+          paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
-        feePaid: paidByUser,
+        feePaid: paidByHotspotOwner,
       }
     }
     default: {

--- a/components/ExportCSV/utils.js
+++ b/components/ExportCSV/utils.js
@@ -117,7 +117,8 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           'Sent Quantity': amountToSellerObject.toString().slice(0, -4),
           'Sent To': txn.seller,
           'Sent Currency': 'HNT',
-          Tag: 'gateway transfer payment',
+          Tag: 'payment',
+          Note: 'gateway transfer payment',
           feePaid: true,
         }
       } else {
@@ -125,7 +126,8 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           'Received Quantity': amountToSellerObject.toString().slice(0, -4),
           'Received From': txn.buyer,
           'Received Currency': 'HNT',
-          Tag: 'gateway transfer payment',
+          Tag: 'payment',
+          Note: 'gateway transfer payment',
         }
       }
     }
@@ -146,7 +148,8 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           : 0,
         'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
-        Tag: `add gateway payment (paid by ${
+        Tag: 'payment',
+        Note: `assert location payment (paid by ${
           paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
         feePaid: paidByHotspotOwner,
@@ -166,7 +169,8 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           : 0,
         'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
-        Tag: `assert location payment (paid by ${
+        Tag: 'payment',
+        Note: `assert location payment (paid by ${
           paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
         feePaid: paidByHotspotOwner,
@@ -186,7 +190,8 @@ const parse = async (ownerAddress, txn, opts = { convertFee: true }) => {
           : 0,
         'Sent To': paidByHotspotOwner ? 'Helium Network' : '',
         'Sent Currency': opts.convertFee ? 'HNT' : 'DC',
-        Tag: `assert location payment (paid by ${
+        Tag: 'payment',
+        Note: `assert location payment (paid by ${
           paidByHotspotOwner ? 'Hotspot owner' : await getMakerName(txn.payer)
         })`,
         feePaid: paidByHotspotOwner,
@@ -220,6 +225,7 @@ export const parseTxn = async (
     'Fee Amount': feePaid ? await getFee(txn, opts.convertFee) : 0,
     'Fee Currency': opts.convertFee ? 'HNT' : 'DC',
     Tag: '',
+    Note: '',
     Hotspot: txn.gateway ? animalHash(txn.gateway) : '',
     'Reward Type': '',
     Block: txn.height,

--- a/components/Makers/utils.js
+++ b/components/Makers/utils.js
@@ -111,3 +111,12 @@ export const getMakerInfo = async (payerAddress, ownerAddress) => {
     return makerName
   }
 }
+
+export const isMakerAddress = async (address) => {
+  if (address === null) return true
+
+  const response = await fetch('https://onboarding.dewi.org/api/v2/makers')
+  const { data: makers } = await response.json()
+  makers.push({ address: DEPRECATED_HELIUM_MAKER_ADDR })
+  return makers.find((m) => m.address === address) !== undefined
+}


### PR DESCRIPTION
fixes #267  and #328 

* adds support for `assert_location_v2` to CSV export
* only shows assert location / add gateway fees if not paid by a maker
* if paid by maker, it'll say which one in the tag column

screenshot:
![Screen Shot 2021-05-10 at 1 45 18 PM](https://user-images.githubusercontent.com/10648471/117722555-0f9b9f80-b196-11eb-9a07-517d4f3772b4.png)
