### PR TITLE
Update 'Create a Challenge' tooltip to mention new challenge interval.

### DIFF
--- a/components/Hotspots/Checklist/Checklist.js
+++ b/components/Hotspots/Checklist/Checklist.js
@@ -122,7 +122,7 @@ const HotspotChecklist = ({ hotspot, witnesses, height, heightLoading }) => {
           sortOrder: 2,
           title: 'Create a Challenge',
           infoTooltipText:
-            'Hotspots that are synced and online create a challenge automatically, every 120 blocks.',
+            'Hotspots that are synced and online create a challenge automatically, every 480 blocks.',
           detailText:
             activity.challengerTxn !== null
               ? `Hotspot issued a challenge ${(


### PR DESCRIPTION
This tooltip still said a challenge was created every 120 blocks. Just updated it to the new (as of this evening) 480 block interval.