### PR TITLE
Beta transaction details fallback fixes

### DIFF
--- a/components/InfoBox/BlockDetailsInfoBox.js
+++ b/components/InfoBox/BlockDetailsInfoBox.js
@@ -168,8 +168,7 @@ const BlockDetailsInfoBox = () => {
           </TabNavbar>
         </>
       ) : (
-        <div className="py-10 px-3 flex items-center justify-center">
-          <Skeleton className="w-full my-2" />
+        <div className="py-10 px-3 flex flex-col items-center justify-center">
           <p className="font-sans text-gray-600 text-lg">No transactions</p>
         </div>
       )}

--- a/components/InfoBox/TxnDetails/Fallback.js
+++ b/components/InfoBox/TxnDetails/Fallback.js
@@ -4,6 +4,14 @@ import AccountWidget from '../../Widgets/AccountWidget'
 import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
 
 const GenericObjectWidget = ({ title, value }) => {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <Widget title={title} value={'Empty array'} span={2} emptyValue />
+    }
+    value.map((v, i) => {
+      return <Widget title={i} value={JSON.stringify(v)} span={2} />
+    })
+  }
   return (
     <div className={classNames(`bg-gray-200 p-3 rounded-lg col-span-2`)}>
       <div className="text-xl font-medium text-black my-1.5 tracking-tight w-full break-all pb-4">
@@ -54,6 +62,9 @@ const Fallback = ({ txn }) => {
 
           // TODO: use a better way to determine if the value is a wallet address
           if (key === 'payer' || key === 'payee' || key === 'owner') {
+            // some txns have a value that is actually the string "undefined"
+            if (value === 'undefined')
+              return <Widget title={key} value={value} span={2} emptyValue />
             return <AccountWidget title={key} address={value} span={2} />
           }
 
@@ -65,10 +76,17 @@ const Fallback = ({ txn }) => {
             }
           }
 
+          // TODO: have a special widget for key === 'geocode'
+
           if (typeof value === 'object') {
             return <GenericObjectWidget title={key} value={value} />
           }
 
+          if (value === '') {
+            return (
+              <Widget title={key} span={2} value={'Empty string'} emptyValue />
+            )
+          }
           return <Widget title={key} span={2} value={value} />
         })}
       </InfoBoxPaneContainer>

--- a/components/InfoBox/TxnDetails/Fallback.js
+++ b/components/InfoBox/TxnDetails/Fallback.js
@@ -1,8 +1,6 @@
 import classNames from 'classnames'
 import Widget from '../../Widgets/Widget'
 import AccountWidget from '../../Widgets/AccountWidget'
-
-import { Balance } from '@helium/currency'
 import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
 
 const GenericObjectWidget = ({ title, value }) => {
@@ -13,6 +11,9 @@ const GenericObjectWidget = ({ title, value }) => {
       </div>
       <div className="space-y-2">
         {Object.entries(value).map(([key, value]) => {
+          if (typeof value === 'object') {
+            return JSON.stringify(value)
+          }
           return (
             <div key={key} className="flex justify-between items-center">
               <div>
@@ -56,12 +57,11 @@ const Fallback = ({ txn }) => {
             return <AccountWidget title={key} address={value} span={2} />
           }
 
-          if (key === 'amount' || key === 'fee') {
+          if (key === 'amount' || key === 'fee' || key === 'stakingFee') {
             if (value === 0) {
               return <Widget title={key} value={value} span={2} />
             } else {
-              const balance = new Balance(value.integerBalance, value.type)
-              return <Widget title={key} value={balance.toString(2)} span={2} />
+              return <Widget title={key} value={value.toString(2)} span={2} />
             }
           }
 

--- a/components/Widgets/Widget.js
+++ b/components/Widgets/Widget.js
@@ -10,6 +10,7 @@ const Widget = ({
   title,
   tooltip,
   value,
+  emptyValue = false,
   copyableValue,
   change,
   changeSuffix,
@@ -46,6 +47,7 @@ const Widget = ({
                 <p
                   className={classNames('flex items-center m-0 p-0', {
                     'cursor-pointer hover:text-gray-800 transition-all duration-150': copyableValue,
+                    'text-gray-400 text-md font-light': emptyValue,
                   })}
                 >
                   <span className="break-all">


### PR DESCRIPTION
fixes #424 : the bug with `gen_gateway_v1` txns (and any other txn types where a field's value is an object with nested objects)

it was happening because `/components/InfoBox/TxnDetails/Fallback.js` was creating a new Balance object to display values, because we used to have to do that when they were coming from Next's `getStaticProps` or `getServerSideProps` which serialized them (`JSON.parse(JSON.stringify(data))`), but now that we're loading data from the client side, they don't have to be serialized and they now still have their functions attached to them from helium-js, so we can just do `value.toString(2)` instead

also added some nicer styling and better handling of certain fallback situations while I was in there (e.g. empty array or string):
![Screen Shot 2021-06-09 at 12 29 08 PM](https://user-images.githubusercontent.com/10648471/121418324-aedfbe00-c91f-11eb-8fef-f1dde914133c.png)
