### PR TITLE
Add manual zoom in/out buttons

### DIFF
--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -160,10 +160,6 @@ const CoverageMap = () => {
       const targetHotspot = await fetchHotspot(target)
       setSelectedTxnHotspot(targetHotspot)
       setSelectedTxnParticipants([])
-    } else if (selectedTxn?.type === 'consensus_group_v1') {
-      const members = await fetchConsensusHotspots(txn.height)
-      setSelectedTxnHotspot(undefined)
-      setSelectedTxnParticipants(members)
     } else {
       setSelectedTxnHotspot(undefined)
       setSelectedTxnParticipants([])

--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -19,6 +19,7 @@ import useApi from '../../hooks/useApi'
 import useSelectedHex from '../../hooks/useSelectedHex'
 import { trackEvent } from '../../hooks/useGA'
 import ScaleLegend from './ScaleLegend'
+import ZoomControls from './ZoomControls'
 
 const maxZoom = 14
 const minZoom = 2
@@ -218,6 +219,7 @@ const CoverageMap = () => {
       }}
       onMouseMove={handleMouseMove}
     >
+      <ZoomControls />
       <ScaleLegend />
       <HexCoverageLayer
         minZoom={minZoom}

--- a/components/Map/ZoomControls.js
+++ b/components/Map/ZoomControls.js
@@ -1,8 +1,17 @@
+import classNames from 'classnames'
 import { ZoomControl } from 'react-mapbox-gl'
+import useInfoBox from '../../hooks/useInfoBox'
 
 const ZoomControls = () => {
+  const { showInfoBox } = useInfoBox()
+
   return (
-    <div className="relative top-14 md:top-20 right-2 md:right-3 zoom-controls">
+    <div
+      className={classNames(
+        'md:flex relative top-14 md:top-20 right-2 md:right-3 zoom-controls transition-all md:pointer-events-auto md:opacity-100',
+        { 'opacity-0 pointer-events-none': showInfoBox },
+      )}
+    >
       <ZoomControl
         style={{
           boxShadow: 'none',

--- a/components/Map/ZoomControls.js
+++ b/components/Map/ZoomControls.js
@@ -1,0 +1,18 @@
+import { ZoomControl } from 'react-mapbox-gl'
+
+const ZoomControls = () => {
+  return (
+    <div className="relative top-14 md:top-20 right-2 md:right-3 zoom-controls">
+      <ZoomControl
+        style={{
+          boxShadow: 'none',
+          inset: 'none',
+          border: 'none',
+          pointerEvents: 'none',
+        }}
+      />
+    </div>
+  )
+}
+
+export default ZoomControls

--- a/styles/Explorer.css
+++ b/styles/Explorer.css
@@ -997,3 +997,47 @@ tr.ant-table-expanded-row-level-1 > td.ant-table-cell {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
+
+.zoom-controls #zoomIn::after {
+  content: '+';
+}
+.zoom-controls #zoomOut::after {
+  content: '-';
+}
+.zoom-controls #zoomIn::after,
+.zoom-controls #zoomOut::after {
+  font-size: 16px;
+  font-family: 'Inter';
+  color: white;
+}
+
+.zoom-controls #zoomIn {
+  border-radius: 10px 10px 0 0 !important;
+}
+.zoom-controls #zoomOut {
+  border-radius: 0 0 10px 10px !important;
+}
+.zoom-controls #zoomIn,
+.zoom-controls #zoomOut {
+  background-color: rgba(16, 23, 37, 0.75) !important;
+  backdrop-filter: saturate(180%) blur(20px);
+  width: 30px !important;
+  height: 30px !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  opacity: 100% !important;
+  pointer-events: auto;
+}
+
+@media (min-width: 768px) {
+  .zoom-controls #zoomIn,
+  .zoom-controls #zoomOut {
+    width: 40px !important;
+    height: 40px !important;
+  }
+
+  .zoom-controls #zoomIn::after,
+  .zoom-controls #zoomOut::after {
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
closes #476 

could probably update it at a later time to be included in the little tool cluster in the bottom right, but that would probably require refactoring that section as well

<img width="616" alt="Screen Shot 2021-06-22 at 3 00 21 PM" src="https://user-images.githubusercontent.com/10648471/123005246-a26d5380-d36a-11eb-8d23-d5332f2c1889.png">
<img width="500" alt="Screen Shot 2021-06-22 at 3 00 31 PM" src="https://user-images.githubusercontent.com/10648471/123005254-a5684400-d36a-11eb-88e2-5556e6a4856c.png">
