### PR TITLE
fuzzy sort the combined hotspot and validator search results

### DIFF
--- a/components/Common/Pill.js
+++ b/components/Common/Pill.js
@@ -11,6 +11,7 @@ const Pill = ({ title, color = 'gray', tooltip }) => (
           'bg-green-500': color === 'green',
           'bg-gray-700': color === 'gray',
           'bg-yellow-500': color === 'yellow',
+          'bg-purple-500': color === 'purple',
           // colors based on reward type
           'bg-reward-witness': color === 'witness',
           'bg-reward-challenger': color === 'challenger',

--- a/components/SearchBar/SearchResult.js
+++ b/components/SearchBar/SearchResult.js
@@ -84,6 +84,11 @@ const SearchResult = ({ result, onSelect, selected = false }) => {
   return null
 }
 
+const pillColors = {
+  validator: 'purple',
+  hotspot: 'green',
+}
+
 const BaseSearchResult = ({ title, subtitle, type, onSelect, selected }) => (
   <div
     className={classNames(
@@ -99,7 +104,7 @@ const BaseSearchResult = ({ title, subtitle, type, onSelect, selected }) => (
       <div className="text-gray-700 text-sm">{subtitle}</div>
     </div>
     <div className="flex items-center px-2">
-      <Pill title={capitalize(type)} />
+      <Pill title={capitalize(type)} color={pillColors[type] || 'gray'} />
     </div>
     <div className="flex">
       <img src="/images/details-arrow.svg" />

--- a/components/SearchBar/useSearchResults.js
+++ b/components/SearchBar/useSearchResults.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { debounce } from 'lodash'
+import Fuse from 'fuse.js'
 import qs from 'qs'
 import client from '../../data/client'
 import { Address } from '@helium/crypto'
@@ -41,7 +42,14 @@ const useSearchResults = () => {
           searchHotspot(term),
           searchValidator(term),
         ])
-        setResults([...results, ...validators, ...hotspots])
+        const items = [...hotspots, ...validators]
+        const fuse = new Fuse(items, {
+          includeScore: true,
+          keys: ['item.name'],
+        })
+        const fuseResults = fuse.search(term)
+        const sortedItems = fuseResults.map((r) => r.item)
+        setResults([...results, ...sortedItems])
       } catch {}
     },
     [results, searchHotspot, searchValidator],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^2.16.1",
     "export-to-csv": "^0.2.1",
     "focus-trap-react": "^8.5.0",
+    "fuse.js": "^6.4.6",
     "geojson": "^0.5.0",
     "geojson2h3": "^1.1.1",
     "h3-js": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7459,6 +7459,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 ganache-cli@^6.1.0:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.2.tgz#c0920f7db0d4ac062ffe2375cb004089806f627a"


### PR DESCRIPTION
uses a client-side fuzzy search library to appropriately sort the combined results of hotspot and validator names. there are a lot of validators now and having their results show up on the top of the list is negatively impacting hotspot search. also color the result pill for hotspots and validators to better distinguish between the two results