### PR TITLE
Fix oracles price charts data (is: ~10days, shouldBe: 30days)

### DIFF
--- a/data/oracles.js
+++ b/data/oracles.js
@@ -10,7 +10,7 @@ export const fetchOraclePrices = async () => {
   var { data: data, cursor: cursor } = await response.json()
   const now = new Date();
   var failsafe = 0;
-  while(1) {
+  while(true) {
     if (failsafe++ >= 20) {
       return prices;
     }

--- a/data/oracles.js
+++ b/data/oracles.js
@@ -24,7 +24,8 @@ export const fetchOraclePrices = async () => {
     for (const el of data) {
       const fromEl = new Date(el.timestamp);
       const diff = now.getTime() - fromEl.getTime();
-      const diffInDays = Math.floor(diff / (1000 * 3600 * 24));
+      const MILLISECONDS_IN_A_DAY = 1000 * 3600 * 24
+      const diffInDays = Math.floor(diff / MILLISECONDS_IN_A_DAY);
       if (diffInDays <= 30) {
         prices.push(el)
       } else {

--- a/data/oracles.js
+++ b/data/oracles.js
@@ -4,29 +4,34 @@ import fetch from 'node-fetch'
 // TODO add price list to helium-js #yolo
 export const fetchOraclePrices = async () => {
   const prices = []
-  const response0 = await fetch('https://api.helium.io/v1/oracle/prices/')
-  const { data: data0, cursor: cursor0 } = await response0.json()
-  prices.push(...data0)
-  const response1 = await fetch(
-    `https://api.helium.io/v1/oracle/prices?cursor=${cursor0}`,
+  const response = await fetch(
+    `https://api.helium.io/v1/oracle/prices/`,
   )
-  const { data: data1, cursor: cursor1 } = await response1.json()
-  prices.push(...data1)
-  const response2 = await fetch(
-    `https://api.helium.io/v1/oracle/prices?cursor=${cursor1}`,
-  )
-  const { data: data2, cursor: cursor2 } = await response2.json()
-  prices.push(...data2)
-  const response3 = await fetch(
-    `https://api.helium.io/v1/oracle/prices?cursor=${cursor2}`,
-  )
-  const { data: data3, cursor: cursor3 } = await response3.json()
-  prices.push(...data3)
-  const response4 = await fetch(
-    `https://api.helium.io/v1/oracle/prices?cursor=${cursor3}`,
-  )
-  const { data: data4 } = await response4.json()
-  prices.push(...data4)
+  var { data: data, cursor: cursor } = await response.json()
+  const now = new Date();
+  var failsafe = 0;
+  while(1) {
+    if (failsafe++ >= 20) {
+      return prices;
+    }
+    const response = await fetch(
+      `https://api.helium.io/v1/oracle/prices?cursor=${cursor}`,
+    )
+    const {data: dataR, cursor: cursorR} = await response.json()
+    data = dataR;
+    cursor = cursorR;
+
+    for (const el of data) {
+      const fromEl = new Date(el.timestamp);
+      const diff = now.getTime() - fromEl.getTime();
+      const diffInDays = Math.floor(diff / (1000 * 3600 * 24));
+      if (diffInDays <= 30) {
+        prices.push(el)
+      } else {
+        return prices
+      }
+    }
+  }
   return prices
 }
 


### PR DESCRIPTION
Current solution pulls 5 consecutive datasets with cursors from the API and then stops (current charts only display data of around 10 days, while being labeled as 30day).

Changed to pulling data with cursors until the received data is older than 30 days. Included failsafe.