### PR TITLE
Fix sync status to use the right height

### DIFF
--- a/components/Widgets/StatusWidget.js
+++ b/components/Widgets/StatusWidget.js
@@ -28,7 +28,7 @@ const StatusWidget = ({ hotspot }) => {
     }
 
     if (
-      hotspot.block - syncHeight >= SYNC_BUFFER_BLOCKS ||
+      hotspot.status.height - syncHeight >= SYNC_BUFFER_BLOCKS ||
       hotspot.status.height === null
     ) {
       return 'Syncing'


### PR DESCRIPTION
Currently the sync display is calculating using `hotspot.block` rather than `hotspot.status.height`, which is the incorrect logic.