### PR TITLE
Fix data only checklist

### DIFF
--- a/components/InfoBox/HotspotDetails/StatisticsPane.js
+++ b/components/InfoBox/HotspotDetails/StatisticsPane.js
@@ -120,7 +120,11 @@ const StatisticsPane = ({ hotspot, isDataOnly }) => {
             </div>
           </div>
         ) : (
-          <ChecklistWidget hotspot={hotspot} witnesses={witnessesData} />
+          <ChecklistWidget
+            hotspot={hotspot}
+            witnesses={witnessesData}
+            isDataOnly={isDataOnly}
+          />
         )}
       </InfoBoxPaneContainer>
     </>


### PR DESCRIPTION
the `isDataOnly` prop just wasn't getting passed into the ChecklistWidget component