### PR TITLE
Add loading state back to /witnesses and /nearby lists

### DIFF
--- a/components/InfoBox/Common/InfoBoxPaneTitleSection.js
+++ b/components/InfoBox/Common/InfoBoxPaneTitleSection.js
@@ -17,7 +17,7 @@ const InfoBoxPaneTitleSection = ({ title, description }) => {
           'pb-2': showDescription,
         })}
       >
-        <span className="font-sans text-800 font-medium text-sm md:text-base">
+        <span className="font-sans text-800 font-medium text-sm md:text-base whitespace-nowrap">
           {title}
         </span>
         {description && title && (

--- a/components/InfoBox/HotspotDetailsInfoBox.js
+++ b/components/InfoBox/HotspotDetailsInfoBox.js
@@ -157,7 +157,7 @@ const HotspotDetailsInfoBox = ({ address, isLoading, hotspot }) => {
           key="witnesses"
           hidden={IS_DATA_ONLY}
         >
-          <WitnessesPane hotspot={hotspot} />
+          {isLoading ? <SkeletonList /> : <WitnessesPane hotspot={hotspot} />}
         </TabPane>
         <TabPane
           title="Nearby"
@@ -165,7 +165,11 @@ const HotspotDetailsInfoBox = ({ address, isLoading, hotspot }) => {
           key="nearby"
           hidden={IS_DATA_ONLY}
         >
-          <NearbyHotspotsPane hotspot={hotspot} />
+          {isLoading ? (
+            <SkeletonList />
+          ) : (
+            <NearbyHotspotsPane hotspot={hotspot} />
+          )}
         </TabPane>
       </TabNavbar>
     </InfoBox>


### PR DESCRIPTION
the WitnessesPane and NearbyHotspotsPane were expecting a full `hotspot` object that was being passed to them as null because I accidentally deleted the loading state when resolving merge conflicts between multiple PRs last week