### PR TITLE
Add current URL to GH issue title on error page

### DIFF
--- a/components/InfoBox/ErrorInfoBox.js
+++ b/components/InfoBox/ErrorInfoBox.js
@@ -3,8 +3,11 @@ import InfoBoxPaneContainer from './Common/InfoBoxPaneContainer'
 import Widget from '../Widgets/Widget'
 import WarningWidget from '../Widgets/WarningWidget'
 import { Helmet } from 'react-helmet'
+import { useLocation } from 'react-router-dom'
 
 const ErrorInfoBox = ({ errorType = 404, errorTitle = '404 — Not Found' }) => {
+  const { pathname: path } = useLocation()
+
   return (
     <>
       <Helmet>
@@ -26,7 +29,7 @@ const ErrorInfoBox = ({ errorType = 404, errorTitle = '404 — Not Found' }) => 
             span={2}
             title="Create an issue on GitHub"
             value="Report a bug"
-            linkTo="https://github.com/helium/explorer/issues/new?labels=bug&template=bug_report.md&title=Unexpected%20404%20error"
+            linkTo={`https://github.com/helium/explorer/issues/new?labels=bug&template=bug_report.md&title=Unexpected%20404%20error%20at%20URL:%20${path}`}
           />
           <Widget
             span={2}

--- a/components/InfoBox/ErrorInfoBox.js
+++ b/components/InfoBox/ErrorInfoBox.js
@@ -8,6 +8,11 @@ import { useLocation } from 'react-router-dom'
 const ErrorInfoBox = ({ errorType = 404, errorTitle = '404 — Not Found' }) => {
   const { pathname: path } = useLocation()
 
+  const issueLink =
+    errorType === 404
+      ? `https://github.com/helium/explorer/issues/new?labels=bug&template=bug_report.yml&title=%5BBug%5D%3A+404%20error%20at%20URL:%20${path}`
+      : `https://github.com/helium/explorer/issues/new?labels=bug&template=bug_report.yml&title=%5BBug%5D%3A+${errorType}%20error%20at%20URL:%20${path}`
+
   return (
     <>
       <Helmet>
@@ -29,7 +34,7 @@ const ErrorInfoBox = ({ errorType = 404, errorTitle = '404 — Not Found' }) => 
             span={2}
             title="Create an issue on GitHub"
             value="Report a bug"
-            linkTo={`https://github.com/helium/explorer/issues/new?labels=bug&template=bug_report.md&title=Unexpected%20404%20error%20at%20URL:%20${path}`}
+            linkTo={issueLink}
           />
           <Widget
             span={2}


### PR DESCRIPTION
will lead to a page with an auto populated title like this:

![Screen Shot 2021-08-02 at 11 35 28 AM](https://user-images.githubusercontent.com/10648471/127907959-92516eb2-8303-4022-956d-4bdec7db5c59.png)
