### PR TITLE
fix issue with state channel close in activity list

### DIFF
--- a/components/InfoBox/TxnDetails/StateChannelCloseV1.js
+++ b/components/InfoBox/TxnDetails/StateChannelCloseV1.js
@@ -23,19 +23,19 @@ const StateChannelCloseV1 = ({ txn }) => {
     let dcTally = 0
     let byteTally = 0
     txn.stateChannel.summaries.forEach((s) => {
-      packetTally += s.num_packets
-      dcTally += s.num_dcs
-      byteTally += s.num_dcs * 24
+      packetTally += s.numPackets
+      dcTally += s.numDcs
+      byteTally += s.numDcs * 24
       parsedData.push({
         client: s.client,
         owner: s.owner,
-        num_packets: s.num_packets,
-        num_dcs: s.num_dcs,
-        num_bytes: s.num_dcs * 24,
+        numPackets: s.numPackets,
+        numDcs: s.numDcs,
+        num_bytes: s.numDcs * 24,
       })
     })
     parsedData.sort((b, a) =>
-      a.num_dcs > b.num_dcs ? 1 : b.num_dcs > a.num_dcs ? -1 : 0,
+      a.numDcs > b.numDcs ? 1 : b.numDcs > a.numDcs ? -1 : 0,
     )
     const hotspotTally = txn.stateChannel.summaries.length
     setTotalPackets(packetTally)
@@ -105,12 +105,12 @@ const StateChannelCloseV1 = ({ txn }) => {
                   <div className="flex flex-col items-end justify-center">
                     <div className="text-sm leading-tight tracking-tighter text-navy-400 font-medium">
                       <span className="pl-1.5">
-                        {p.num_dcs.toLocaleString()} DC
+                        {p.numDcs.toLocaleString()} DC
                       </span>
                     </div>
                     <div className="text-sm leading-tight tracking-tighter text-gray-600 pt-1">
-                      {p.num_packets.toLocaleString()}{' '}
-                      {p.num_packets === 1 ? 'packet ' : 'packets '}
+                      {p.numPackets.toLocaleString()}{' '}
+                      {p.numPackets === 1 ? 'packet ' : 'packets '}
                       <span className="text-navy-600 pl-1.5">
                         {formatBytes(p.num_bytes)}
                       </span>

--- a/components/Lists/ActivityList/ActivityList.js
+++ b/components/Lists/ActivityList/ActivityList.js
@@ -189,23 +189,8 @@ const ActivityList = ({
           )
 
         case 'state_channel_close_v1':
-          const summary = txn?.stateChannel?.summaries
-          return (
-            <>
-              {timestamp}
-              <span className="flex items-center justify-start">
-                <img alt="" src="/images/dc.svg" className="h-3 w-auto mr-1" />
-                <span className="mr-1">
-                  {txn.stateChannel.summaries[0].num_dcs} DC
-                </span>
-                <span>
-                  {`(${summary[0]?.num_packets} packet${
-                    summary[0]?.num_packets === 1 ? '' : 's'
-                  })`}
-                </span>
-              </span>
-            </>
-          )
+          return timestamp
+
         case 'stake_validator_v1':
           return (
             <>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@feedback-fish/react": "^1.2.1",
     "@helium/crypto": "^3.1.0",
     "@helium/currency": "^3.25.1",
-    "@helium/http": "^3.38.3",
+    "@helium/http": "^3.38.5",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "@next/bundle-analyzer": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.38.3":
-  version "3.38.3"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.38.3.tgz#eb63cbb2c264a0e2381496c69e588171a921326f"
-  integrity sha512-6lot2oM/H7RpW+L+SBWj9nT1saIJU45TxLVonqprtsjAB453fPW0Bn+puZGrEBa/+qCiosdeebewUG+C014HcA==
+"@helium/http@^3.38.5":
+  version "3.38.5"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.38.5.tgz#7b8e07802083987807e51d6f885adf3c0a498891"
+  integrity sha512-S9mCeCcVJ0YQi9LliD8D19LKCoCTJJUqQlAEf4AxF7ETS+KqcPngwnBdxoHII/d7qL/MonroqZU2Y0CY6q8B0g==
   dependencies:
     "@helium/currency" "^3.25.1"
     axios "^0.21.1"


### PR DESCRIPTION
1. there was an issue where we weren't handling empty lists for state channel summaries
2. however it appears that summaries have been removed from activity list endpoints so I removed any summary detail from the list item
3. I also updated `@helium/http` to use the now-defined `StateChannelCloseV1` txn type with camel casing