### PR TITLE
fix validators showing stale data

### DIFF
--- a/components/InfoBox/ValidatorDetails/OverviewPane.js
+++ b/components/InfoBox/ValidatorDetails/OverviewPane.js
@@ -58,12 +58,12 @@ const OverviewPane = () => {
         title="Earnings"
       />
       <PenaltyWidget validator={validator} />
-      <Widget
+      {/* <Widget
         title="ISP"
         isLoading={isLoading}
         span={2}
         value={<ISP validator={validator} />}
-      />
+      /> */}
     </InfoBoxPaneContainer>
   )
 }

--- a/components/InfoBox/ValidatorDetailsInfoBox.js
+++ b/components/InfoBox/ValidatorDetailsInfoBox.js
@@ -17,21 +17,21 @@ const ValidatorDetailsInfoBox = () => {
   const generateSubtitles = useCallback(() => {
     if (isLoading)
       return [
-        {
-          iconPath: '/images/location-blue.svg',
-          loading: true,
-        },
+        // {
+        //   iconPath: '/images/location-blue.svg',
+        //   loading: true,
+        // },
         {
           iconPath: '/images/account-green.svg',
           loading: true,
         },
       ]
     return [
-      {
-        iconPath: '/images/location-blue.svg',
-        // path: `/cities/${hotspot.geocode.cityId}`,
-        title: <ValidatorFlagLocation geo={validator.geo} />,
-      },
+      // {
+      //   iconPath: '/images/location-blue.svg',
+      //   // path: `/cities/${hotspot.geocode.cityId}`,
+      //   title: <ValidatorFlagLocation geo={validator.geo} />,
+      // },
       {
         iconPath: '/images/account-green.svg',
         title: <AccountAddress address={validator.owner} truncate={5} />,

--- a/components/InfoBox/Validators/AllValidatorsPane.js
+++ b/components/InfoBox/Validators/AllValidatorsPane.js
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+import { useElections } from '../../../data/consensus'
+import { useValidators } from '../../../data/validators'
+import ValidatorsList from '../../Lists/ValidatorsList'
+import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
+
+const AllValidatorsPane = () => {
+  const { validators, fetchMore, isLoadingInitial, isLoadingMore, hasMore } =
+    useValidators()
+
+  const { consensusGroups } = useElections()
+
+  const recentGroups = useMemo(
+    () => consensusGroups?.recentElections || [],
+    [consensusGroups],
+  )
+
+  return (
+    <InfoBoxPaneContainer span={1} padding={false}>
+      <ValidatorsList
+        validators={validators}
+        recentGroups={recentGroups}
+        title={'All Validators'}
+        fetchMore={fetchMore}
+        isLoading={isLoadingInitial}
+        isLoadingMore={isLoadingMore}
+        hasMore={hasMore}
+      />
+    </InfoBoxPaneContainer>
+  )
+}
+
+export default AllValidatorsPane

--- a/components/InfoBox/Validators/ConsensusGroupPane.js
+++ b/components/InfoBox/Validators/ConsensusGroupPane.js
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { useConsensusGroup, useElections } from '../../../data/consensus'
+import ValidatorsList from '../../Lists/ValidatorsList'
+import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
+
+const ConsensusGroupPane = () => {
+  const { consensusGroups } = useElections()
+  const { consensusGroup } = useConsensusGroup()
+
+  const recentGroups = useMemo(
+    () => consensusGroups?.recentElections || [],
+    [consensusGroups],
+  )
+
+  const isLoading = useMemo(
+    () => !consensusGroups || !consensusGroup,
+    [consensusGroups, consensusGroup],
+  )
+
+  return (
+    <InfoBoxPaneContainer span={1} padding={false}>
+      <ValidatorsList
+        validators={consensusGroup}
+        recentGroups={recentGroups}
+        title={`Currently Elected Validators (${consensusGroup?.length})`}
+        isLoading={isLoading}
+      />
+    </InfoBoxPaneContainer>
+  )
+}
+
+export default ConsensusGroupPane

--- a/components/InfoBox/ValidatorsInfoBox.js
+++ b/components/InfoBox/ValidatorsInfoBox.js
@@ -1,40 +1,28 @@
 import InfoBox from './InfoBox'
 import TabNavbar, { TabPane } from '../Nav/TabNavbar'
 import Widget from '../Widgets/Widget'
-import { useMemo } from 'react'
 import { clamp } from 'lodash'
 import { formatLargeNumber, formatPercent } from '../../utils/format'
 import VersionsWidget from '../Widgets/VersionsWidget'
 import { useElections } from '../../data/consensus'
-import ValidatorsList from '../Lists/ValidatorsList'
 import useApi from '../../hooks/useApi'
 import InfoBoxPaneContainer from './Common/InfoBoxPaneContainer'
-import SkeletonList from '../Lists/SkeletonList'
 import StatWidget from '../Widgets/StatWidget'
 import { differenceInDays } from 'date-fns'
 import { useValidatorStats } from '../../data/validators'
 import Currency from '../Common/Currency'
 import { useMarket } from '../../data/market'
 import ElectionsPane from './Common/ElectionsPane'
+import AllValidatorsPane from './Validators/AllValidatorsPane'
+import ConsensusGroupPane from './Validators/ConsensusGroupPane'
 
 const TICKER = 'HNT'
 
 const ValidatorsInfoBox = () => {
-  const { data: validators } = useApi('/validators')
   const { data: stats } = useApi('/metrics/validators')
   const { consensusGroups } = useElections()
   const { stats: validatorStats } = useValidatorStats()
   const { market } = useMarket()
-
-  const isLoading = useMemo(() => validators === undefined, [validators])
-
-  const recentGroups = useMemo(() => consensusGroups?.recentElections || [], [
-    consensusGroups,
-  ])
-
-  const consensusGroup = useMemo(() => validators?.filter((v) => v.elected), [
-    validators,
-  ])
 
   return (
     <InfoBox title="Validators" metaTitle="Validators">
@@ -91,37 +79,17 @@ const ValidatorsInfoBox = () => {
               valueType="percent"
               changeType="percent"
             />
-            <VersionsWidget validators={validators} isLoading={isLoading} />
+            <VersionsWidget />
           </InfoBoxPaneContainer>
         </TabPane>
         <TabPane title="Elections" key="elections" path="elections">
           <ElectionsPane />
         </TabPane>
         <TabPane title="Consensus Group" key="consensus" path="consensus">
-          <InfoBoxPaneContainer span={1} padding={false}>
-            {isLoading ? (
-              <SkeletonList />
-            ) : (
-              <ValidatorsList
-                validators={consensusGroup}
-                recentGroups={recentGroups}
-                title={`Currently Elected Validators (${consensusGroup?.length})`}
-              />
-            )}
-          </InfoBoxPaneContainer>
+          <ConsensusGroupPane />
         </TabPane>
         <TabPane title="All Validators" key="all" path="all">
-          <InfoBoxPaneContainer span={1} padding={false}>
-            {isLoading ? (
-              <SkeletonList />
-            ) : (
-              <ValidatorsList
-                validators={validators}
-                recentGroups={recentGroups}
-                title={`All Validators (${validators?.length})`} // maybe redundant because of the #XXX next to each validator?
-              />
-            )}
-          </InfoBoxPaneContainer>
+          <AllValidatorsPane />
         </TabPane>
       </TabNavbar>
     </InfoBox>

--- a/components/Lists/ValidatorsList.js
+++ b/components/Lists/ValidatorsList.js
@@ -35,12 +35,6 @@ const ValidatorsList = ({
     return (
       <>
         {/* <ValidatorFlagLocation geo={v.geo} /> */}
-        {/* <Tooltip title="HNT earned (30 days)">
-          <div className="flex items-center space-x-1">
-            <img alt="" src="/images/hnt.svg" className="w-3" />{' '}
-            <span>{round(v.rewards.month.total, 2)} HNT</span>
-          </div>
-        </Tooltip> */}
         <Rewards validator={v} />
         <Tooltip title="Penalty Score">
           <div className="flex items-center space-x-1">

--- a/components/Lists/ValidatorsList.js
+++ b/components/Lists/ValidatorsList.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback } from 'react'
 import animalHash from 'angry-purple-tiger'
 import { round } from 'lodash'
 import { Tooltip } from 'antd'
@@ -6,19 +6,18 @@ import ConsensusIndicator from '../Validators/ConsensusIndicator'
 import ValidatorFlagLocation from '../Validators/ValidatorFlagLocation'
 import ValidatorStatusDot from '../Validators/ValidatorStatusDot'
 import BaseList from './BaseList'
+import Rewards from '../Validators/Rewards'
 
-const ValidatorsList = ({ validators, recentGroups, title, description }) => {
-  const [index, setIndex] = useState(20)
-
-  const fetchMore = useCallback(() => {
-    setIndex((prevIndex) => prevIndex + 20)
-  }, [])
-
-  const validatorsToDisplay = useMemo(() => validators.slice(0, index), [
-    index,
-    validators,
-  ])
-
+const ValidatorsList = ({
+  validators,
+  recentGroups,
+  title,
+  description,
+  fetchMore,
+  hasMore,
+  isLoading,
+  isLoadingMore,
+}) => {
   const keyExtractor = useCallback((v) => v.address, [])
 
   const linkExtractor = useCallback((v) => `/validators/${v.address}`, [])
@@ -27,7 +26,7 @@ const ValidatorsList = ({ validators, recentGroups, title, description }) => {
     return (
       <div className="flex items-center space-x-1">
         <ValidatorStatusDot status={v.status} />
-        <span>{`${animalHash(v.address)} (#${v.number})`}</span>
+        <span>{`${animalHash(v.address)}`}</span>
       </div>
     )
   }, [])
@@ -35,13 +34,14 @@ const ValidatorsList = ({ validators, recentGroups, title, description }) => {
   const renderSubtitle = useCallback((v) => {
     return (
       <>
-        <ValidatorFlagLocation geo={v.geo} />
-        <Tooltip title="HNT earned (30 days)">
+        {/* <ValidatorFlagLocation geo={v.geo} /> */}
+        {/* <Tooltip title="HNT earned (30 days)">
           <div className="flex items-center space-x-1">
             <img alt="" src="/images/hnt.svg" className="w-3" />{' '}
             <span>{round(v.rewards.month.total, 2)} HNT</span>
           </div>
-        </Tooltip>
+        </Tooltip> */}
+        <Rewards validator={v} />
         <Tooltip title="Penalty Score">
           <div className="flex items-center space-x-1">
             <img src="/images/penalty.svg" className="w-3" />{' '}
@@ -63,14 +63,15 @@ const ValidatorsList = ({ validators, recentGroups, title, description }) => {
 
   return (
     <BaseList
-      items={validatorsToDisplay}
+      items={validators}
       fetchMore={fetchMore}
-      hasMore={index < validators.length - 1}
+      isLoading={isLoading}
+      hasMore={hasMore}
+      isLoadingMore={isLoadingMore}
       listHeaderTitle={title}
       listHeaderDescription={description}
       keyExtractor={keyExtractor}
       linkExtractor={linkExtractor}
-      isLoading={false}
       renderTitle={renderTitle}
       renderSubtitle={renderSubtitle}
       renderDetails={renderDetails}

--- a/components/SearchBar/SearchResult.js
+++ b/components/SearchBar/SearchResult.js
@@ -3,7 +3,7 @@ import Timestamp from 'react-timestamp'
 import FlagLocation from '../Common/FlagLocation'
 import { formatHotspotName } from '../Hotspots/utils'
 import Pill from '../Common/Pill'
-import { capitalize } from 'lodash'
+import { capitalize, round } from 'lodash'
 import { useCallback } from 'react'
 import AccountAddress from '../AccountAddress'
 import ValidatorFlagLocation from '../Validators/ValidatorFlagLocation'
@@ -31,7 +31,13 @@ const SearchResult = ({ result, onSelect, selected = false }) => {
     return (
       <BaseSearchResult
         title={formatHotspotName(result.item.name)}
-        subtitle={<ValidatorFlagLocation geo={result.item.geo} />}
+        // subtitle={<ValidatorFlagLocation geo={result.item.geo} />}
+        subtitle={
+          <div className="flex items-center space-x-1">
+            <img src="/images/penalty.svg" className="w-3" />{' '}
+            <span>{round(result.item.penalty, 2)}</span>
+          </div>
+        }
         type={result.type}
         selected={selected}
         onSelect={handleSelect}

--- a/components/SearchBar/useSearchResults.js
+++ b/components/SearchBar/useSearchResults.js
@@ -34,9 +34,9 @@ const useSearchResults = () => {
   const searchValidator = useCallback(
     async (term) => {
       try {
-        const validators = await fetchApi(`/validators/search?term=${term}`)
-        const results = validators.map((v) =>
-          toSearchResult(camelcaseKeys(v), 'validator'),
+        const list = await client.validators.search(term)
+        const results = (await list.take(20)).map((v) =>
+          toSearchResult(v, 'validator'),
         )
         dispatch({
           type: PUSH_RESULTS,

--- a/components/Validators/Rewards.js
+++ b/components/Validators/Rewards.js
@@ -1,0 +1,23 @@
+import { round } from '@turf/helpers'
+import { Tooltip } from 'antd'
+import Skeleton from '../Common/Skeleton'
+import { useValidatorRewardsSum } from '../../data/rewards'
+
+const Rewards = ({ validator }) => {
+  const { rewardsSum, isLoading } = useValidatorRewardsSum(validator.address, 30)
+
+  if (isLoading) {
+    return <Skeleton className="w-1/4" />
+  }
+
+  return (
+    <Tooltip title="HNT earned (30 days)">
+      <div className="flex items-center space-x-1">
+        <img alt="" src="/images/hnt.svg" className="w-3" />{' '}
+        <span>{round(rewardsSum, 2)} HNT</span>
+      </div>
+    </Tooltip>
+  )
+}
+
+export default Rewards

--- a/components/Widgets/VersionsWidget.js
+++ b/components/Widgets/VersionsWidget.js
@@ -20,10 +20,11 @@ const VersionsWidget = () => {
   const { data: versionCounts } = useApi('/validators/versions')
 
   const isLoading = useMemo(() => !versionCounts, [versionCounts])
-  const totalValidators = useMemo(
-    () => sum(Object.values(versionCounts)),
-    [versionCounts],
-  )
+  const totalValidators = useMemo(() => {
+    if (!versionCounts) return 0
+
+    return sum(Object.values(versionCounts))
+  }, [versionCounts])
 
   return (
     <div className="bg-gray-200 p-3 rounded-lg col-span-2">

--- a/components/Widgets/VersionsWidget.js
+++ b/components/Widgets/VersionsWidget.js
@@ -1,7 +1,8 @@
-import { countBy, maxBy } from 'lodash'
+import { max, sum } from 'lodash'
 import { Tooltip } from 'antd'
-import { filterEligibleValidators, formatVersion } from '../Validators/utils'
+import { formatVersion } from '../Validators/utils'
 import { useMemo } from 'react'
+import useApi from '../../hooks/useApi'
 
 const makePercent = (count, total) => (count / total) * 100 + '%'
 
@@ -15,18 +16,14 @@ const versionColor = (version, index) => {
   return green
 }
 
-const VersionsWidget = ({ validators = [], isLoading = false }) => {
-  const eligibleValidators = useMemo(
-    () => validators.filter(filterEligibleValidators),
-    [validators],
-  )
+const VersionsWidget = () => {
+  const { data: versionCounts } = useApi('/validators/versions')
 
-  const versionCounts = useMemo(
-    () => countBy(eligibleValidators, 'versionHeartbeat'),
-    [eligibleValidators],
+  const isLoading = useMemo(() => !versionCounts, [versionCounts])
+  const totalValidators = useMemo(
+    () => sum(Object.values(versionCounts)),
+    [versionCounts],
   )
-
-  const totalValidators = eligibleValidators.length
 
   return (
     <div className="bg-gray-200 p-3 rounded-lg col-span-2">
@@ -62,9 +59,7 @@ const VersionsWidget = ({ validators = [], isLoading = false }) => {
         ) : (
           <span className="font-mono text-gray-800 text-sm">
             Latest Version:{' '}
-            {formatVersion(
-              maxBy(eligibleValidators, 'versionHeartbeat')?.versionHeartbeat,
-            ) || ' N/A'}
+            {formatVersion(max(Object.keys(versionCounts))) || ' N/A'}
           </span>
         )}
       </div>

--- a/data/consensus.js
+++ b/data/consensus.js
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import Client, { Network } from '@helium/http'
+import client, { TAKE_MAX } from './client'
 
 export const fetchElections = (network = 'production') => async () => {
   const clientNetwork =
@@ -34,6 +35,28 @@ export const useElections = (initialData, network = 'production') => {
   )
   return {
     consensusGroups: data,
+    isLoading: !error && !data,
+    isError: error,
+  }
+}
+
+export const fetchElected = async () => {
+  const list = await client.validators.elected()
+  const validators = await list.take(TAKE_MAX)
+  return validators
+}
+
+export const useConsensusGroup = (initialData) => {
+  const { data, error } = useSWR(
+    'consensusGroup',
+    fetchElected,
+    {
+      initialData,
+      refreshInterval: 10000,
+    },
+  )
+  return {
+    consensusGroup: data,
     isLoading: !error && !data,
     isError: error,
   }

--- a/data/rewards.js
+++ b/data/rewards.js
@@ -60,6 +60,7 @@ export const useHotspotRewardsSum = (
 
   const { data, error } = useSWR(key, fetcher(address, numBack, bucketType), {
     refreshInterval: 0,
+    dedupingInterval: 60 * 1000 * 10,
   })
 
   return {
@@ -154,6 +155,37 @@ export const useRewardBuckets = (address, type, numBack = 30, bucketType = 'day'
   return {
     rewards: data,
     isLoading: !error && !data,
+    isError: error,
+  }
+}
+
+export const fetchValidatorRewardsSum = async (address, numBack, bucketType) => {
+  const response = await fetch(
+    `https://api.helium.io/v1/validators/${address}/rewards/sum/?min_time=-${numBack}%20${bucketType}`,
+  )
+  const {
+    data: { total },
+  } = await response.json()
+  return total
+}
+
+export const useValidatorRewardsSum = (
+  address,
+  numBack = 1,
+  bucketType = 'day',
+) => {
+  const key = `rewards/validators/${address}/sum/${numBack}/${bucketType}`
+  const fetcher = (address, numBack, bucketType) => () =>
+    fetchValidatorRewardsSum(address, numBack, bucketType)
+
+  const { data, error } = useSWR(key, fetcher(address, numBack, bucketType), {
+    refreshInterval: 0,
+    dedupingInterval: 60 * 1000 * 10,
+  })
+
+  return {
+    rewardsSum: data,
+    isLoading: !error && data === undefined,
     isError: error,
   }
 }


### PR DESCRIPTION
this avoids the explorer-api for loading validator data, which results in fresher data, however we will need to hide ip geolocation fields for now until that has been moved in the main api

related issue for that: https://github.com/helium/blockchain-http/issues/321

We also will no longer get a "number" for a validator. If that's an issue for anyone, we can explore providing that from the main API.

We also need to load 30d reward sums ad hoc in parallel similar to what we're already doing for hotspots, since that's no longer being included in cached data