### PR TITLE
Fix nearby hotspot distance calculation

### DIFF
--- a/data/hotspots.js
+++ b/data/hotspots.js
@@ -57,8 +57,8 @@ export const fetchNearbyHotspots = async (lat, lon, distance = 1000) => {
       haversineDistance(
         lon,
         lat,
-        h3ToGeo(h.location_hex)[1],
-        h3ToGeo(h.location_hex)[0],
+        h3ToGeo(h.locationHex)[1],
+        h3ToGeo(h.locationHex)[0],
       ) * 1000,
   }))
   return hotspotsWithDistance


### PR DESCRIPTION
it was looking for the field `location_hex` instead of `locationHex` (from #647 ), resulting in wrong distances being shown for the nearby tab:

![image](https://user-images.githubusercontent.com/10648471/130118229-f48eec88-945f-4b8b-9996-a5ddff0e6913.png)
https://discord.com/channels/404106811252408320/750533049623773304/877747723271553054