### PR TITLE
adding HDS as a monitoring tool option

### DIFF
--- a/data/communitytools.js
+++ b/data/communitytools.js
@@ -30,6 +30,12 @@ export const communityToolsList = [
     tags: ['Data Export'],
   },
   {
+    name: 'HDS - Hotspot Discord Status',
+    url: 'https://www.github.com/co8/hds',
+    description: 'Activity and Reward Notifications sent to your Discord Channel',
+    tags: ['Monitoring'],
+  },
+  {
     name: 'Helistats',
     url: 'https://apps.apple.com/us/app/helistats/id1573119107',
     description:
@@ -110,12 +116,6 @@ export const communityToolsList = [
     url: 'https://helium.nebra.com/handy-guides/local-diagnostics',
     description:
       'Local diagnostics utility for Nebra Hotspots including syncing, firmware, and other useful info.',
-    tags: ['Monitoring'],
-  },
-  {
-    name: 'HDS - Hotspot Discord Status',
-    url: 'https://www.github.com/co8/hds',
-    description: 'Activity and Reward Notifications sent to your Discord Channel',
     tags: ['Monitoring'],
   },
 

--- a/data/communitytools.js
+++ b/data/communitytools.js
@@ -112,6 +112,12 @@ export const communityToolsList = [
       'Local diagnostics utility for Nebra Hotspots including syncing, firmware, and other useful info.',
     tags: ['Monitoring'],
   },
+  {
+    name: 'HDS - Hotspot Discord Status',
+    url: 'https://www.github.com/co8/hds',
+    description: 'Activity and Reward Notifications sent to your Discord Channel',
+    tags: ['Monitoring'],
+  },
 
   // The lines below are a template that you can copy and paste and then populate
   // to add a new tool to the list.All the possible tags are included in the


### PR DESCRIPTION
I've created a python script to monitor the Helium API for my hotspot. I call it HDS, Hotspot Discord Status

https://github.com/co8/hds

It delivers minimal, fun, campy messages to your discord channel via webhook.

I run it on a RasPi ZeroW using python and cron.

thanks!
Enrique
e@co8.com