### PR TITLE
Add Heliumbot.io to community tools

### DIFF
--- a/data/communitytools.js
+++ b/data/communitytools.js
@@ -49,6 +49,12 @@ export const communityToolsList = [
     tags: ['Monitoring', 'Data Export'],
   },
   {
+    name: 'Heliumbot.io',
+    url: 'https://heliumbot.io',
+    description: 'Managed hotspot monitoring and profit calculation service providing push notifications',
+    tags: ['Monitoring'],
+  },
+  {
     name: 'Helium Hosts',
     url: 'https://heliumhosts.com/',
     description: 'Network with other Hotspot owners in your area',


### PR DESCRIPTION
heliumbot.io is a managed service for hotspot monitoring and profit calculations providing push notifications which can be configured by users.