### PR TITLE
Block navigation fixes

### DIFF
--- a/components/InfoBox/BlockDetailsInfoBox.js
+++ b/components/InfoBox/BlockDetailsInfoBox.js
@@ -14,7 +14,6 @@ import TabNavbar, { TabPane } from '../Nav/TabNavbar'
 import classNames from 'classnames'
 import TransactionTypesWidget from '../Widgets/TransactionTypesWidget'
 import SkeletonList from '../Lists/SkeletonList'
-import { useHistory } from 'react-router-dom'
 import { useBlockHeight } from '../../data/blocks'
 import PreviousIcon from '../Icons/Previous'
 import NextIcon from '../Icons/Next'
@@ -25,7 +24,6 @@ import BlockTimestamp from '../Common/BlockTimestamp'
 const BlockDetailsInfoBox = () => {
   const { height: currentHeight } = useBlockHeight()
   const { block: height } = useParams()
-  const history = useHistory()
 
   const [block, setBlock] = useState({})
   const [blockLoading, setBlockLoading] = useState(true)
@@ -46,8 +44,6 @@ const BlockDetailsInfoBox = () => {
     setTxnsLoading(true)
     const txns = await fetchBlockTxns(height)
     const splitTxns = splitTransactionsByTypes(txns)
-    if (splitTxns.length > 0)
-      history.push(`/blocks/${height}/${splitTxns[0].type}`)
     setTxns({ splitTxns, txns })
     setTxnsLoading(false)
   }, [height])
@@ -116,7 +112,6 @@ const BlockDetailsInfoBox = () => {
           iconPath: '/images/block-purple.svg',
           title: `${formattedTxnHash(block.hash)}`,
           textToCopy: block.hash,
-          newRow: true,
         },
       ],
     ]
@@ -153,10 +148,13 @@ const BlockDetailsInfoBox = () => {
         <>
           <TransactionTypesWidget txns={txns.txns} />
           <TabNavbar
+            {...(txns?.splitTxns?.length
+              ? { basePath: `/${txns.splitTxns[0].type}` }
+              : {})}
             centered={false}
             className="w-full border-b border-gray-400 border-solid mt-0 px-2 md:px-4 flex overflow-x-scroll no-scrollbar"
           >
-            {txns?.splitTxns.map((type) => {
+            {txns?.splitTxns.map((type, i) => {
               return (
                 <TabPane
                   title={
@@ -175,7 +173,7 @@ const BlockDetailsInfoBox = () => {
                     </div>
                   }
                   key={type.type}
-                  path={type.type}
+                  {...(i !== 0 ? { path: type.type } : {})}
                   customStyles
                   classes={'text-gray-600 hover:text-gray-800'}
                   activeClasses={'border-b-3 border-solid'}

--- a/components/InfoBox/BlocksInfoPanes/BlockStatisticsPane.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockStatisticsPane.js
@@ -49,7 +49,11 @@ const BlockStatisticsPane = () => {
       <StatWidget
         title="Block Height"
         series={blocks?.height}
-        linkTo={`/blocks/${blocks?.height[blocks?.height?.length - 1]?.value}`}
+        linkTo={
+          blocks?.height?.length
+            ? `/blocks/${blocks.height[blocks.height.length - 1].value}`
+            : '/blocks'
+        }
         isLoading={!blocks}
       />
       <StatWidget

--- a/components/Nav/TabNavbar.js
+++ b/components/Nav/TabNavbar.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useEffect, useRef } from 'react'
 import { matchPath } from 'react-router'
 import {
   Switch,
@@ -21,9 +21,31 @@ const NavItem = ({
   href,
 }) => {
   const customStyles = classes || activeClasses || activeStyles
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (active)
+      ref.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest',
+      })
+  }, [active, ref])
+
+  const styles = {
+    // scroll-margin tells the browser to leave a margin around it when using it as a scroll target
+    scrollMargin: 32 + 20,
+    // 32px is the width of the bouncing scroll indicator, and 20px is the padding at the end of the list
+    // 32 + 20 so that:
+    // 1. if it's jumping to the last item, it won't leave a scroll indicator that jumps to nothing
+    // 2. if it's not the last item, the ones behind it will peek out slightly and won't be fully obscured by the scroll indicator)
+  }
+
   return (
     <Link
       to={href}
+      // jump to the active element (setting a ref triggers the useEffect above)
+      {...(active ? { ref: ref } : {})}
       className={classNames(
         classes,
         active ? activeClasses : '',
@@ -34,7 +56,7 @@ const NavItem = ({
             active && !customStyles,
         },
       )}
-      style={active ? activeStyles : {}}
+      style={active ? { ...activeStyles, ...styles } : styles}
     >
       {title}
     </Link>


### PR DESCRIPTION
fixes #689 partially

this PR makes it so the most common transaction type in a block becomes the base path, e.g.:

- `/blocks/1009632` will show the "PoC Challenge" tab highlighted
- clicking another type tab (e.g. "Validator Heartbeat") will be reflected in the URL, like: `/blocks/1009632/validator_heartbeat_v1`

this PR does _not_ fix the issue of unsaved scroll position when navigating between pages though. that will be a very helpful addition, but I think it will require a bit more involved changes to how loading/displaying data works. it would also likely work differently with pages that have infinite scroll loading versus pages where all the content is known when it's displayed (such as block details), and we should probably do it in a way that will save scroll positions within lists everywhere we can