### PR TITLE
Disable changing filter until loading complete

### DIFF
--- a/components/InfoBox/Common/ActivityPane.js
+++ b/components/InfoBox/Common/ActivityPane.js
@@ -89,6 +89,7 @@ const ActivityPane = ({ context, address }) => {
             value,
           }))}
           activeItem={filter}
+          disabled={isLoadingInitial || isLoadingMore}
           onClick={handleUpdateFilter}
         />
       </div>

--- a/components/Nav/PillNavbar.js
+++ b/components/Nav/PillNavbar.js
@@ -5,19 +5,21 @@ import { useScrollIndicators } from '../../hooks/useScrollIndicators'
 import ScrollIndicator from '../../hooks/useScrollIndicators'
 import { useRef } from 'react'
 
-const NavItem = ({ title, active = false, onClick, type }) => {
+const NavItem = ({ title, active = false, onClick, type, disabled }) => {
   const handleClick = useCallback(() => {
     onClick(title)
   }, [onClick, title])
 
   return (
     <span
-      onClick={handleClick}
+      // don't allow clicking to another filter until the current one has finished loading
+      {...(!disabled ? { onClick: handleClick } : {})}
       className={classNames(
         'py-1 px-2.5 mr-0 md:mr-1 flex font-medium text-sm md:text-base cursor-pointer whitespace-nowrap transition-all transform duration-200',
         {
           'text-gray-700': !active,
           'text-white rounded-full': active,
+          'cursor-wait ': disabled,
         },
       )}
       style={active ? { backgroundColor: getTxnTypeColor(type) } : {}}
@@ -27,7 +29,7 @@ const NavItem = ({ title, active = false, onClick, type }) => {
   )
 }
 
-const PillNavbar = ({ navItems, activeItem, onClick }) => {
+const PillNavbar = ({ navItems, activeItem, onClick, disabled }) => {
   const scrollContainer = useRef(null)
 
   const {
@@ -51,6 +53,7 @@ const PillNavbar = ({ navItems, activeItem, onClick }) => {
             type={item.value[0]}
             active={item.key === activeItem}
             onClick={onClick}
+            disabled={disabled}
           />
         ))}
         <span className="pr-4" />


### PR DESCRIPTION
fixes #693

this probably isn't the best way to fix this, but should work for now, and actually could help a tiny bit with curbing excessive /activity API calls (since it has to do a different fetch every time the filter changes)

I tried a bunch of different changes to the way the activity lists get fetched, but the bug kept persisting if you click between filters quickly enough

some of the things I tried (that didn't work) before landing on this fix:
- changing `useAsync` to `useEffect` with a defined `async` function that gets called immediately
- adding `filter` as a dependency to all of the `useAsync` functions in `data/activity/useActivity.js`
- setting the activity list to empty when the initial activity fetch starts
- showing `<SkeletonList />` instead of `<ActivityList />` if `useActivity` is returning `isLoadingInitial` or `isLoadingMore`