### PR TITLE
Remove status indicator for data only hotspots

### DIFF
--- a/components/InfoBox/HotspotDetailsInfoBox.js
+++ b/components/InfoBox/HotspotDetailsInfoBox.js
@@ -9,7 +9,6 @@ import ActivityPane from './Common/ActivityPane'
 import WitnessesPane from './HotspotDetails/WitnessesPane'
 import NearbyHotspotsPane from './HotspotDetails/NearbyHotspotsPane'
 import useSelectedHotspot from '../../hooks/useSelectedHotspot'
-import CopyableText from '../Common/CopyableText'
 import AccountAddress from '../AccountAddress'
 import SkeletonList from '../Lists/SkeletonList'
 import FlagLocation from '../Common/FlagLocation'
@@ -18,7 +17,6 @@ import Elevation from '../Hotspots/Elevation'
 import { isDataOnly } from '../Hotspots/utils'
 import SkeletonWidgets from './Common/SkeletonWidgets'
 import HexIndex from '../Common/HexIndex'
-import MakerIcon from '../Icons/MakerIcon'
 import { useMaker } from '../../data/makers'
 import Skeleton from '../Common/Skeleton'
 import { useCallback } from 'react'
@@ -94,11 +92,19 @@ const HotspotDetailsInfoBox = ({ address, isLoading, hotspot }) => {
         ]
       return [
         [
-          {
-            iconPath: '/images/maker.svg',
-            title: makerLoading ? <Skeleton /> : <span>{maker?.name}</span>,
-            path: `/accounts/${maker?.address}`,
-          },
+          ...(!isDataOnly(hotspot)
+            ? [
+                {
+                  iconPath: '/images/maker.svg',
+                  title: makerLoading ? (
+                    <Skeleton />
+                  ) : (
+                    <span>{maker?.name}</span>
+                  ),
+                  path: `/accounts/${maker?.address}`,
+                },
+              ]
+            : []),
           {
             iconPath: '/images/gain.svg',
             title: <Gain hotspot={hotspot} icon={false} />,

--- a/components/Lists/HexHotspotsList.js
+++ b/components/Lists/HexHotspotsList.js
@@ -8,6 +8,7 @@ import { useRewardBuckets } from '../../data/rewards'
 import RewardScaleHex from '../Common/RewardScaleHex'
 import Skeleton from '../Common/Skeleton'
 import HotspotTimeAgo from '../Common/HotspotTimeAgo'
+import { isDataOnly } from '../Hotspots/utils'
 
 const HexHotspotsList = ({
   hotspots,
@@ -73,7 +74,7 @@ const HotspotItem = ({ hotspot }) => {
     <>
       <div className="w-full">
         <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans">
-          <StatusCircle status={hotspot.status} />
+          {!isDataOnly(hotspot) && <StatusCircle status={hotspot.status} />}
           {animalHash(hotspot.address)}
         </div>
         <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">

--- a/components/Lists/HotspotsList.js
+++ b/components/Lists/HotspotsList.js
@@ -8,6 +8,7 @@ import Gain from '../Hotspots/Gain'
 import Elevation from '../Hotspots/Elevation'
 import Rewards from '../Hotspots/Rewards'
 import TransmitScale from '../Hotspots/TransmitScale'
+import { isDataOnly } from '../Hotspots/utils'
 
 const HotspotsList = ({
   hotspots,
@@ -32,7 +33,7 @@ const HotspotsList = ({
   const renderTitle = useCallback((h) => {
     return (
       <>
-        <StatusCircle status={h.status} />
+        {!isDataOnly(h) && <StatusCircle status={h.status} />}
         {animalHash(h.address)}
       </>
     )


### PR DESCRIPTION
fixes #703:

![Screen Shot 2021-09-27 at 10 49 41 AM](https://user-images.githubusercontent.com/10648471/134959628-c1b5d971-0854-4fc0-a4d4-b74231856893.png)

also removed the maker icon/name from the subtitles section for data only hotspots: 
![Screen Shot 2021-09-27 at 10 49 48 AM](https://user-images.githubusercontent.com/10648471/134959658-b7e94367-7466-4f7f-9833-0ebb68324a30.png)
