### PR TITLE
Load block transactions progressively

### DIFF
--- a/components/InfoBox/BlockDetailsInfoBox.js
+++ b/components/InfoBox/BlockDetailsInfoBox.js
@@ -20,6 +20,8 @@ import NextIcon from '../Icons/Next'
 import InfoBoxTitleButton from './Common/InfoBoxTitleButton'
 import Skeleton from '../Common/Skeleton'
 import BlockTimestamp from '../Common/BlockTimestamp'
+import BlockTransactionsList from './BlocksInfoPanes/BlockTransactionsList'
+import InfoBoxPaneContainer from './Common/InfoBoxPaneContainer'
 
 const BlockDetailsInfoBox = () => {
   const { height: currentHeight } = useBlockHeight()
@@ -28,8 +30,8 @@ const BlockDetailsInfoBox = () => {
   const [block, setBlock] = useState({})
   const [blockLoading, setBlockLoading] = useState(true)
 
-  const [txns, setTxns] = useState({})
-  const [txnsLoading, setTxnsLoading] = useState(true)
+  // const [txns, setTxns] = useState({})
+  // const [txnsLoading, setTxnsLoading] = useState(true)
 
   useAsync(async () => {
     // get block metadata (for subtitles)
@@ -39,14 +41,14 @@ const BlockDetailsInfoBox = () => {
     setBlockLoading(false)
   }, [height])
 
-  useAsync(async () => {
-    // get transactions (for the list and the tabs)
-    setTxnsLoading(true)
-    const txns = await fetchBlockTxns(height)
-    const splitTxns = splitTransactionsByTypes(txns)
-    setTxns({ splitTxns, txns })
-    setTxnsLoading(false)
-  }, [height])
+  // useAsync(async () => {
+  //   // get transactions (for the list and the tabs)
+  //   setTxnsLoading(true)
+  //   const txns = await fetchBlockTxns(height)
+  //   const splitTxns = splitTransactionsByTypes(txns)
+  //   setTxns({ splitTxns, txns })
+  //   setTxnsLoading(false)
+  // }, [height])
 
   const title = useMemo(() => {
     const blockHeight = parseInt(height)
@@ -117,10 +119,10 @@ const BlockDetailsInfoBox = () => {
     ]
   }
 
-  if (txnsLoading) {
+  if (blockLoading) {
     return (
       <InfoBox title={title} subtitles={generateSubtitles(block)}>
-        <div
+        {/* <div
           className="bg-white px-5 pt-3 rounded-lg col-span-2"
           style={{ width: '100%', minHeight: 60 + 76 }}
         >
@@ -131,7 +133,7 @@ const BlockDetailsInfoBox = () => {
             <Skeleton className="w-1/4 h-10" />
             <Skeleton className="w-1/4 h-10" />
           </div>
-        </div>
+        </div> */}
         <SkeletonList />
       </InfoBox>
     )
@@ -144,10 +146,11 @@ const BlockDetailsInfoBox = () => {
       subtitles={generateSubtitles(block)}
       breadcrumbs={[{ title: 'Blocks', path: '/blocks/latest' }]}
     >
-      {txns?.txns?.length > 0 ? (
-        <>
-          <TransactionTypesWidget txns={txns.txns} />
-          <TabNavbar
+      {/* {txns?.txns?.length > 0 ? ( */}
+
+      <BlockTransactionsList height={height} />
+      {/* <TransactionTypesWidget txns={txns.txns} /> */}
+      {/* <TabNavbar
             {...(txns?.splitTxns?.length
               ? { basePath: `/${txns.splitTxns[0].type}` }
               : {})}
@@ -199,13 +202,13 @@ const BlockDetailsInfoBox = () => {
                 </TabPane>
               )
             })}
-          </TabNavbar>
-        </>
-      ) : (
+          </TabNavbar> */}
+
+      {/* ) : (
         <div className="py-10 px-3 flex flex-col items-center justify-center">
-          <p className="font-sans text-gray-600 text-lg">No transactions</p>
+        <p className="font-sans text-gray-600 text-lg">No transactions</p>
         </div>
-      )}
+      )} */}
     </InfoBox>
   )
 }

--- a/components/InfoBox/BlockDetailsInfoBox.js
+++ b/components/InfoBox/BlockDetailsInfoBox.js
@@ -122,18 +122,6 @@ const BlockDetailsInfoBox = () => {
   if (blockLoading) {
     return (
       <InfoBox title={title} subtitles={generateSubtitles(block)}>
-        {/* <div
-          className="bg-white px-5 pt-3 rounded-lg col-span-2"
-          style={{ width: '100%', minHeight: 60 + 76 }}
-        >
-          <Skeleton className="h-6 w-full my-3 rounded-lg flex overflow-hidden" />
-          <div className="flex items-center justify-start pt-5 space-x-4">
-            <Skeleton className="w-1/4 h-10" />
-            <Skeleton className="w-1/4 h-10" />
-            <Skeleton className="w-1/4 h-10" />
-            <Skeleton className="w-1/4 h-10" />
-          </div>
-        </div> */}
         <SkeletonList />
       </InfoBox>
     )
@@ -146,69 +134,7 @@ const BlockDetailsInfoBox = () => {
       subtitles={generateSubtitles(block)}
       breadcrumbs={[{ title: 'Blocks', path: '/blocks/latest' }]}
     >
-      {/* {txns?.txns?.length > 0 ? ( */}
-
       <BlockTransactionsList height={height} />
-      {/* <TransactionTypesWidget txns={txns.txns} /> */}
-      {/* <TabNavbar
-            {...(txns?.splitTxns?.length
-              ? { basePath: `/${txns.splitTxns[0].type}` }
-              : {})}
-            centered={false}
-            className="w-full border-b border-gray-400 border-solid mt-0 px-2 md:px-4 flex overflow-x-scroll no-scrollbar"
-          >
-            {txns?.splitTxns.map((type, i) => {
-              return (
-                <TabPane
-                  title={
-                    <div className="">
-                      <p
-                        style={{ color: getTxnTypeColor(type.type) }}
-                        className={'mb-0 text-xl'}
-                      >
-                        {type.txns.length}
-                      </p>
-                      <p
-                        className={classNames('text-sm mb-0 whitespace-nowrap')}
-                      >
-                        {getTxnTypeName(type.type)}
-                      </p>
-                    </div>
-                  }
-                  key={type.type}
-                  {...(i !== 0 ? { path: type.type } : {})}
-                  customStyles
-                  classes={'text-gray-600 hover:text-gray-800'}
-                  activeClasses={'border-b-3 border-solid'}
-                  activeStyles={{
-                    borderColor: getTxnTypeColor(type.type),
-                    color: 'black',
-                  }}
-                >
-                  <div
-                    className={classNames(
-                      'grid grid-flow-row grid-cols-1 no-scrollbar',
-                      {
-                        'overflow-y-scroll': !blockLoading,
-                        'overflow-y-hidden': blockLoading,
-                      },
-                    )}
-                  >
-                    <TransactionList
-                      transactions={type.txns}
-                      isLoading={blockLoading}
-                    />
-                  </div>
-                </TabPane>
-              )
-            })}
-          </TabNavbar> */}
-
-      {/* ) : (
-        <div className="py-10 px-3 flex flex-col items-center justify-center">
-        <p className="font-sans text-gray-600 text-lg">No transactions</p>
-        </div>
-      )} */}
     </InfoBox>
   )
 }

--- a/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
@@ -1,8 +1,13 @@
 import classNames from 'classnames'
 import { memo, useCallback } from 'react'
 import { useFetchBlockTxns } from '../../../data/blocks'
+import { getTxnTypeName } from '../../../utils/txns'
+import BlockTimestamp from '../../Common/BlockTimestamp'
 import BaseList from '../../Lists/BaseList'
-import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
+import animalHash from 'angry-purple-tiger'
+import AccountIcon from '../../AccountIcon'
+import AccountAddress from '../../AccountAddress'
+import ChevronIcon from '../../Icons/Chevron'
 
 const BlockTransactionsList = ({ height }) => {
   const {
@@ -19,36 +24,275 @@ const BlockTransactionsList = ({ height }) => {
 
   const linkExtractor = useCallback((txn) => `/txns/${txn.hash}`, [])
 
-  // const renderItem = useCallback((txn) => {
-  //   return (
-  //     <div className="flex w-full">
-  //       <div className="w-full">
-  //         <div className="flex flex-row items-center justify-start">
-  //           <span className="text-navy-400 font-bold text-base pr-1">
-  //             {txn?.type}
-  //           </span>
-  //           <span className="text-black text-base font-semibold">
-  //             {txn?.hash}
-  //           </span>
-  //         </div>
-  //       </div>
-  //       <div className="flex items-center">
-  //         <img alt="" src="/images/details-arrow.svg" />
-  //       </div>
-  //     </div>
-  //   )
-  // }, [])
-
-  const renderTitle = useCallback((t) => {
-    return t.type
+  const renderItem = useCallback((txn) => {
+    return (
+      <>
+        <div className="w-full">
+          <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
+            {renderTitle(txn)}
+          </div>
+          <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">
+            {renderSubtitle(txn)}
+          </div>
+        </div>
+        <div className="flex items-center px-4 text-xs md:text-sm font-sans text-gray-525">
+          {renderDetails(txn)}
+        </div>
+        {linkExtractor && (
+          <div className="flex items-center">
+            <img alt="" src="/images/details-arrow.svg" />
+          </div>
+        )}
+      </>
+    )
   }, [])
 
-  const renderSubtitle = useCallback((t) => {
-    return t.hash
+  const renderTitle = useCallback((txn) => {
+    switch (txn.type) {
+      case 'poc_request_v1':
+        return (
+          <span className="flex items-center">
+            <span className="flex items-center text-black font-sans font-medium">
+              {animalHash(txn.challenger)}
+            </span>
+          </span>
+        )
+      case 'poc_receipts_v1':
+        return (
+          <span className="flex items-center">
+            <span className="flex items-center text-black font-sans font-medium">
+              {animalHash(txn.path[0].challengee)}
+            </span>
+          </span>
+        )
+      case 'add_gateway_v1':
+        return (
+          <span className="flex items-center text-black font-sans font-medium">
+            {animalHash(txn.gateway)}
+          </span>
+        )
+      case 'assert_location_v1':
+      case 'assert_location_v2':
+        return (
+          <span className="flex items-center text-black font-sans font-medium">
+            {animalHash(txn.gateway)}
+          </span>
+        )
+      case 'payment_v1':
+        return (
+          <span className="flex items-center whitespace-nowrap">
+            <span className="flex items-center text-black font-sans font-medium">
+              {txn.amount.toString(2)}
+            </span>
+          </span>
+        )
+      case 'payment_v2':
+        return (
+          <span className="flex items-center whitespace-nowrap">
+            <span className="flex items-center text-black font-sans font-medium">
+              {txn.totalAmount.toString(2)}
+            </span>
+          </span>
+        )
+      case 'stake_validator_v1':
+      case 'validator_heartbeat_v1':
+        return (
+          <span className="flex items-center">
+            <span className="flex items-center text-black font-sans font-medium">
+              {animalHash(txn.address)}
+            </span>
+          </span>
+        )
+      default:
+        return <span className="text-black">{getTxnTypeName(txn.type)}</span>
+    }
+  }, [])
+
+  const renderSubtitle = useCallback((txn) => {
+    const timestamp = (
+      <span className="flex items-center space-x-1">
+        <img alt="" src="/images/clock.svg" className="h-3 w-auto" />
+        <BlockTimestamp blockTime={txn.time} className="tracking-tight" />
+      </span>
+    )
+    switch (txn.type) {
+      case 'poc_request_v1':
+        const address = txn.challengerOwner ? txn.challengerOwner : txn.owner
+        return (
+          <div className="flex items-center justify-end text-gray-600">
+            {address ? (
+              <>
+                <AccountIcon size={12} address={address} />
+                <span className="pl-1 ">
+                  <AccountAddress
+                    clickable={false}
+                    address={address}
+                    truncate={4}
+                    mono
+                  />
+                </span>
+              </>
+            ) : (
+              timestamp
+            )}
+          </div>
+        )
+      case 'add_gateway_v1':
+        return (
+          <div className="flex items-center justify-end text-gray-600">
+            <AccountIcon size={12} address={txn.owner} />
+            <span className="pl-1 ">
+              <AccountAddress
+                clickable={false}
+                address={txn.owner}
+                truncate={4}
+                mono
+              />
+            </span>
+          </div>
+        )
+      case 'poc_receipts_v1':
+        return (
+          <span className="flex items-center">
+            <img
+              alt=""
+              src="/images/challenger-icon.svg"
+              className="h-3 w-auto"
+            />
+            <span className="ml-1.5 whitespace-nowrap text-sm font-sans">
+              {animalHash(txn.challenger)}
+            </span>
+            <span className="ml-3 flex flex-row items-center justify-start">
+              <img
+                alt=""
+                src="/images/witness-yellow-mini.svg"
+                className="h-3 w-auto"
+              />
+              <span className="ml-1.5 text-sm font-sans">
+                {txn.path[0].witnesses.length}
+              </span>
+            </span>
+          </span>
+        )
+      case 'assert_location_v1':
+      case 'assert_location_v2':
+        return (
+          <span className="flex items-center space-x-1">
+            <img
+              alt=""
+              src="/images/location-hex.svg"
+              className="h-3 w-auto mr-1"
+            />
+            {txn.location}
+          </span>
+        )
+      case 'payment_v1':
+        return (
+          <span className="flex items-center space-x-2">
+            <div className="flex items-center justify-end text-gray-600">
+              <AccountIcon size={12} address={txn.payer} />
+              <span className="pl-1 ">
+                <AccountAddress
+                  clickable={false}
+                  address={txn.payer}
+                  truncate={4}
+                  mono
+                />
+              </span>
+            </div>
+            <ChevronIcon className="text-gray-600 rotate-90 transform h-3 w-auto" />
+            <div className="flex items-center justify-end text-gray-600">
+              <AccountIcon size={12} address={txn.payee} />
+              <span className="pl-1 ">
+                <AccountAddress
+                  clickable={false}
+                  address={txn.payee}
+                  truncate={4}
+                  mono
+                />
+              </span>
+            </div>
+          </span>
+        )
+      case 'payment_v2':
+        return (
+          <span className="flex items-center space-x-2">
+            <div className="flex items-center justify-end text-gray-600">
+              <AccountIcon size={12} address={txn.payer} />
+              <span className="pl-1 ">
+                <AccountAddress
+                  clickable={false}
+                  address={txn.payer}
+                  truncate={4}
+                  mono
+                />
+              </span>
+            </div>
+            <ChevronIcon className="text-gray-600 rotate-90 transform h-3 w-auto" />
+            {txn.payments.length === 1 ? (
+              <div className="flex items-center justify-end text-gray-600">
+                <AccountIcon size={12} address={txn.payments[0].payee} />
+                <span className="pl-1 ">
+                  <AccountAddress
+                    clickable={false}
+                    address={txn.payments[0].payee}
+                    truncate={4}
+                    mono
+                  />
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center justify-end text-gray-600">
+                {txn.payments.length} payees
+              </div>
+            )}
+          </span>
+        )
+      case 'stake_validator_v1':
+        return (
+          <span className="flex items-center space-x-1 md:space-x-3">
+            <div className="flex items-center justify-end text-gray-600">
+              <AccountIcon size={12} address={txn.owner} />
+              <span className="pl-1 ">
+                <AccountAddress
+                  clickable={false}
+                  address={txn.owner}
+                  truncate={4}
+                  mono
+                />
+              </span>
+            </div>
+            <span className="flex items-center justify-start space-x-1">
+              <img alt="" src="/images/hnt.svg" className="w-4 mr-1" />
+              {txn.stake.toString(2)}
+            </span>
+          </span>
+        )
+      case 'validator_heartbeat_v1':
+        return (
+          <span className="flex items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-3 w-3 text-txn-heartbeat"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span className="ml-1">{txn.version}</span>
+          </span>
+        )
+      default:
+        return timestamp
+    }
   }, [])
 
   const renderDetails = useCallback((t) => {
-    return t.time
+    return null
   }, [])
 
   return (
@@ -66,12 +310,12 @@ const BlockTransactionsList = ({ height }) => {
         fetchMore={fetchMore}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        renderTitle={renderTitle}
-        renderSubtitle={renderSubtitle}
+        // renderTitle={renderTitle}
+        // renderSubtitle={renderSubtitle}
         renderDetails={renderDetails}
         blankTitle="No Transactions"
-        // renderItem={renderItem}
-        // render
+        renderItem={renderItem}
+        render
       />
     </div>
   )

--- a/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
@@ -1,13 +1,14 @@
 import classNames from 'classnames'
 import { memo, useCallback } from 'react'
 import { useFetchBlockTxns } from '../../../data/blocks'
-import { getTxnTypeName } from '../../../utils/txns'
+import { getTxnTypeColor, getTxnTypeName } from '../../../utils/txns'
 import BlockTimestamp from '../../Common/BlockTimestamp'
 import BaseList from '../../Lists/BaseList'
 import animalHash from 'angry-purple-tiger'
 import AccountIcon from '../../AccountIcon'
 import AccountAddress from '../../AccountAddress'
 import ChevronIcon from '../../Icons/Chevron'
+import ActivityColorSlice from '../../Lists/ActivityList/ActivityColorSlice'
 
 const BlockTransactionsList = ({ height }) => {
   const {
@@ -24,28 +25,43 @@ const BlockTransactionsList = ({ height }) => {
 
   const linkExtractor = useCallback((txn) => `/txns/${txn.hash}`, [])
 
-  const renderItem = useCallback((txn) => {
+  const renderItem = useCallback(
+    (txn) => {
+      return (
+        <>
+          <ActivityColorSlice highlightColor={getTxnTypeColor(txn.type)} />
+          <div className="w-full px-4 py-2">
+            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
+              {renderTxnType(txn)}
+            </div>
+            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
+              {renderTitle(txn)}
+            </div>
+            <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">
+              {renderSubtitle(txn)}
+            </div>
+          </div>
+          <div className="flex items-center px-4 text-xs md:text-sm font-sans text-gray-525">
+            {renderDetails(txn)}
+          </div>
+          {linkExtractor && (
+            <div className="flex items-center">
+              <img alt="" src="/images/details-arrow.svg" />
+            </div>
+          )}
+        </>
+      )
+    },
+    [linkExtractor, renderDetails, renderSubtitle, renderTxnType],
+  )
+
+  const renderTxnType = useCallback((txn) => {
     return (
-      <>
-        <div className="w-full">
-          <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
-            {renderTitle(txn)}
-          </div>
-          <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">
-            {renderSubtitle(txn)}
-          </div>
-        </div>
-        <div className="flex items-center px-4 text-xs md:text-sm font-sans text-gray-525">
-          {renderDetails(txn)}
-        </div>
-        {linkExtractor && (
-          <div className="flex items-center">
-            <img alt="" src="/images/details-arrow.svg" />
-          </div>
-        )}
-      </>
+      <span className="text-xs text-gray-700 whitespace-nowrap">
+        {getTxnTypeName(txn.type)}
+      </span>
     )
-  }, [])
+  })
 
   const renderTitle = useCallback((txn) => {
     switch (txn.type) {
@@ -310,12 +326,11 @@ const BlockTransactionsList = ({ height }) => {
         fetchMore={fetchMore}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        // renderTitle={renderTitle}
-        // renderSubtitle={renderSubtitle}
         renderDetails={renderDetails}
         blankTitle="No Transactions"
         renderItem={renderItem}
         render
+        itemPadding={false}
       />
     </div>
   )

--- a/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
@@ -19,8 +19,6 @@ const BlockTransactionsList = ({ height }) => {
     hasMore,
   } = useFetchBlockTxns(height)
 
-  // console.log(txns)
-
   const keyExtractor = useCallback((txn) => txn.hash, [])
 
   const linkExtractor = useCallback((txn) => `/txns/${txn.hash}`, [])

--- a/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
@@ -23,43 +23,13 @@ const BlockTransactionsList = ({ height }) => {
 
   const linkExtractor = useCallback((txn) => `/txns/${txn.hash}`, [])
 
-  const renderItem = useCallback(
-    (txn) => {
-      return (
-        <>
-          <ActivityColorSlice highlightColor={getTxnTypeColor(txn.type)} />
-          <div className="w-full px-4 py-2">
-            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
-              {renderTxnType(txn)}
-            </div>
-            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
-              {renderTitle(txn)}
-            </div>
-            <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">
-              {renderSubtitle(txn)}
-            </div>
-          </div>
-          <div className="flex items-center px-4 text-xs md:text-sm font-sans text-gray-525">
-            {renderDetails(txn)}
-          </div>
-          {linkExtractor && (
-            <div className="flex items-center">
-              <img alt="" src="/images/details-arrow.svg" />
-            </div>
-          )}
-        </>
-      )
-    },
-    [linkExtractor, renderDetails, renderSubtitle, renderTxnType],
-  )
-
   const renderTxnType = useCallback((txn) => {
     return (
       <span className="text-xs text-gray-700 whitespace-nowrap">
         {getTxnTypeName(txn.type)}
       </span>
     )
-  })
+  }, [])
 
   const renderTitle = useCallback((txn) => {
     switch (txn.type) {
@@ -308,6 +278,36 @@ const BlockTransactionsList = ({ height }) => {
   const renderDetails = useCallback((t) => {
     return null
   }, [])
+
+  const renderItem = useCallback(
+    (txn) => {
+      return (
+        <>
+          <ActivityColorSlice highlightColor={getTxnTypeColor(txn.type)} />
+          <div className="w-full px-4 py-2">
+            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
+              {renderTxnType(txn)}
+            </div>
+            <div className="text-sm md:text-base font-medium text-darkgray-800 font-sans whitespace-nowrap">
+              {renderTitle(txn)}
+            </div>
+            <div className="flex items-center space-x-4 h-6 text-gray-525 text-xs md:text-sm whitespace-nowrap">
+              {renderSubtitle(txn)}
+            </div>
+          </div>
+          <div className="flex items-center px-4 text-xs md:text-sm font-sans text-gray-525">
+            {renderDetails(txn)}
+          </div>
+          {linkExtractor && (
+            <div className="flex items-center px-4">
+              <img alt="" src="/images/details-arrow.svg" />
+            </div>
+          )}
+        </>
+      )
+    },
+    [linkExtractor, renderDetails, renderSubtitle, renderTitle, renderTxnType],
+  )
 
   return (
     <div

--- a/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockTransactionsList.js
@@ -1,0 +1,80 @@
+import classNames from 'classnames'
+import { memo, useCallback } from 'react'
+import { useFetchBlockTxns } from '../../../data/blocks'
+import BaseList from '../../Lists/BaseList'
+import InfoBoxPaneContainer from '../Common/InfoBoxPaneContainer'
+
+const BlockTransactionsList = ({ height }) => {
+  const {
+    results: txns,
+    fetchMore,
+    isLoadingInitial,
+    isLoadingMore,
+    hasMore,
+  } = useFetchBlockTxns(height)
+
+  // console.log(txns)
+
+  const keyExtractor = useCallback((txn) => txn.hash, [])
+
+  const linkExtractor = useCallback((txn) => `/txns/${txn.hash}`, [])
+
+  // const renderItem = useCallback((txn) => {
+  //   return (
+  //     <div className="flex w-full">
+  //       <div className="w-full">
+  //         <div className="flex flex-row items-center justify-start">
+  //           <span className="text-navy-400 font-bold text-base pr-1">
+  //             {txn?.type}
+  //           </span>
+  //           <span className="text-black text-base font-semibold">
+  //             {txn?.hash}
+  //           </span>
+  //         </div>
+  //       </div>
+  //       <div className="flex items-center">
+  //         <img alt="" src="/images/details-arrow.svg" />
+  //       </div>
+  //     </div>
+  //   )
+  // }, [])
+
+  const renderTitle = useCallback((t) => {
+    return t.type
+  }, [])
+
+  const renderSubtitle = useCallback((t) => {
+    return t.hash
+  }, [])
+
+  const renderDetails = useCallback((t) => {
+    return t.time
+  }, [])
+
+  return (
+    <div
+      className={classNames('grid grid-flow-row grid-cols-1 no-scrollbar', {
+        'overflow-y-scroll': !isLoadingInitial,
+        'overflow-y-hidden': isLoadingInitial,
+      })}
+    >
+      <BaseList
+        items={txns}
+        keyExtractor={keyExtractor}
+        linkExtractor={linkExtractor}
+        isLoading={!txns || isLoadingInitial}
+        fetchMore={fetchMore}
+        isLoadingMore={isLoadingMore}
+        hasMore={hasMore}
+        renderTitle={renderTitle}
+        renderSubtitle={renderSubtitle}
+        renderDetails={renderDetails}
+        blankTitle="No Transactions"
+        // renderItem={renderItem}
+        // render
+      />
+    </div>
+  )
+}
+
+export default memo(BlockTransactionsList)

--- a/data/blocks.js
+++ b/data/blocks.js
@@ -44,10 +44,42 @@ export const fetchBlock = async (height) => {
 }
 
 export const fetchBlockTxns = async (height) => {
-  const txns = await (await client.block(height).transactions.list()).take(
-    TAKE_MAX,
-  )
+  const txns = await (
+    await client.block(height).transactions.list()
+  ).take(TAKE_MAX)
   return txns
+}
+
+export const useFetchBlockTxns = (height, pageSize = 50) => {
+  const [list, setList] = useState()
+  const [results, setResults] = useState([])
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(true)
+
+  useAsync(async () => {
+    const newList = await client.block(height).transactions.list()
+    setList(newList)
+    setIsLoadingInitial(false)
+  }, [])
+
+  useAsync(async () => {
+    if (!list) return
+    setIsLoadingMore(true)
+    const newResults = await list.take(pageSize)
+    setResults(newResults)
+    setIsLoadingMore(false)
+    if (newResults.length < pageSize) {
+      setHasMore(false)
+    }
+  }, [list])
+
+  const fetchMore = useCallback(async () => {
+    const newResults = await list.take(pageSize)
+    setResults([...results, ...newResults])
+  }, [list, pageSize, results])
+
+  return { results, fetchMore, isLoadingInitial, isLoadingMore, hasMore }
 }
 
 export const useFetchBlocks = (pageSize = 20) => {


### PR DESCRIPTION
Fixes #715 

Right now, `/blocks/:blocknumber` has to pull all of the block transactions before displaying them. The UI breaks it into all the different transaction types in the block, which it can't do without loading them all:
![Screen Shot 2021-10-04 at 5 41 46 PM](https://user-images.githubusercontent.com/10648471/135942955-55e2a4e3-897e-44c5-9d16-c7e8df453ee8.png)


This worked okay when there were <200 transactions per block, but doesn't work great now that there are 1000+. It takes a long time to load, because it probably requests way more than it should have to from the API.

This PR refactors this view to fetch the transactions progressively as you scroll, like so:
![2021-10-04 17 52 31](https://user-images.githubusercontent.com/10648471/135943702-a5786638-72b2-4726-b98c-d720d282dfde.gif)

Obviously this is not ideal in terms of UX, since it doesn't allow for easily finding transactions within a given block. Below I've outlined how we can get the best of both worlds, potentially in a future PR:

# Future considerations
If we want to keep the UI this way (which I think I would lean toward, since it is a very useful way to look at what is in a block), we would probably need 2 API changes:
1. inside the block 'metadata' (`/blocks/:height`), if we could get a breakdown of the transaction types, in addition to the `transaction_count` field, we could populate the transaction types widget at the top with that info. For example:
```json
{
    "data": {
        "transaction_count": 9,
        "transaction_types": {
            "poc_request_v1": 5,
            "poc_receipts_v1": 3,
            "add_gateway_v1": 1
        },
        "time": 1572472462,
        "snapshot_hash": "",
        "prev_hash": "I8LYrdL-Imq34IDwUCuMUYI2opUN9wcfJvt1hKJffzo",
        "height": 100000,
        "hash": "pqHszXWVprhh0yuIbH8usdIixQ9NiSoc1RSjP1-hu4Q"
    }
}
```
2. We would need the ability to filter by transaction types when fetching the transactions from a block. Right now there is just `/blocks/:height/transactions`, and a `cursor` query param. We would need a `filter_types` param like the `/activity` endpoint has.

I've put the above 2 requests in https://github.com/helium/blockchain-http/issues/339