### PR TITLE
Fix hex map snapping

### DIFF
--- a/components/InfoBox/HexDetailsInfoBox.js
+++ b/components/InfoBox/HexDetailsInfoBox.js
@@ -8,11 +8,20 @@ import HexHotspotsList from '../Lists/HexHotspotsList'
 import { useCallback } from 'react'
 import { formatLocation } from '../Hotspots/utils'
 import FlagLocation from '../Common/FlagLocation'
+import useSelectedHex from '../../hooks/useSelectedHex'
 
 const HexDetailsInfoBox = () => {
   const { index } = useParams()
 
   const { result: hotspots, loading } = useAsync(fetchHexHotspots, [index])
+
+  const { selectedHex, selectHex } = useSelectedHex(index)
+
+  useAsync(async () => {
+    if (!selectedHex) {
+      selectHex(index)
+    }
+  }, [selectedHex, index])
 
   const generateSubtitles = useCallback((hotspot) => {
     if (!hotspot)

--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -24,6 +24,7 @@ import MeasuringPointsLayer from './Layers/MeasuringPointsLayer'
 import { useRouteMatch } from 'react-router-dom'
 import classNames from 'classnames'
 import useSelectedCity from '../../hooks/useSelectedCity'
+import { h3ToGeo } from 'h3-js'
 
 const maxZoom = 14
 const minZoom = 2
@@ -145,7 +146,7 @@ const CoverageMap = () => {
   useEffect(() => {
     if (!selectedHex) return
 
-    const [lat, lng] = selectedHex.center
+    const [lat, lng] = h3ToGeo(selectedHex.index)
     const selectionBounds = findBounds([
       { lat, lng },
       ...paddingPoints({ lat, lng }),

--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -146,7 +146,7 @@ const CoverageMap = () => {
   useEffect(() => {
     if (!selectedHex) return
 
-    const [lat, lng] = h3ToGeo(selectedHex.index)
+    const [lat, lng] = selectedHex.center
     const selectionBounds = findBounds([
       { lat, lng },
       ...paddingPoints({ lat, lng }),

--- a/components/Map/Map.js
+++ b/components/Map/Map.js
@@ -24,7 +24,6 @@ import MeasuringPointsLayer from './Layers/MeasuringPointsLayer'
 import { useRouteMatch } from 'react-router-dom'
 import classNames from 'classnames'
 import useSelectedCity from '../../hooks/useSelectedCity'
-import { h3ToGeo } from 'h3-js'
 
 const maxZoom = 14
 const minZoom = 2


### PR DESCRIPTION
Fixes #722 to allow direct links to hexes to snap to their location on the map

It was broken because the hex detail view wasn't "selecting" the hex from the URL to fetch its information