### PR TITLE
Remove hotspot count from paginated hotspot lists

### DIFF
--- a/components/InfoBox/AccountDetails/HotspotsPane.js
+++ b/components/InfoBox/AccountDetails/HotspotsPane.js
@@ -3,13 +3,8 @@ import { useHotspots } from '../../../data/hotspots'
 import HotspotsList from '../../Lists/HotspotsList'
 
 const HotspotsPane = ({ address }) => {
-  const {
-    hotspots,
-    fetchMore,
-    isLoadingInitial,
-    isLoadingMore,
-    hasMore,
-  } = useHotspots('account', address)
+  const { hotspots, fetchMore, isLoadingInitial, isLoadingMore, hasMore } =
+    useHotspots('account', address)
 
   return (
     <div
@@ -24,6 +19,7 @@ const HotspotsPane = ({ address }) => {
         isLoadingMore={isLoadingMore}
         fetchMore={fetchMore}
         hasMore={hasMore}
+        showCount
       />
     </div>
   )

--- a/components/Lists/HotspotsList.js
+++ b/components/Lists/HotspotsList.js
@@ -60,7 +60,7 @@ const HotspotsList = ({
     <BaseList
       items={hotspots}
       keyExtractor={keyExtractor}
-      listHeaderTitle="Hotspots"
+      listHeaderTitle={showCount ? 'Hotspots' : null}
       listHeaderShowCount={showCount}
       linkExtractor={linkExtractor}
       onSelectItem={handleSelectHotspot}

--- a/components/Lists/HotspotsList.js
+++ b/components/Lists/HotspotsList.js
@@ -16,6 +16,7 @@ const HotspotsList = ({
   fetchMore,
   isLoadingMore,
   hasMore,
+  showCount = false,
 }) => {
   const { selectHotspot } = useSelectedHotspot()
 
@@ -60,7 +61,7 @@ const HotspotsList = ({
       items={hotspots}
       keyExtractor={keyExtractor}
       listHeaderTitle="Hotspots"
-      listHeaderShowCount={true}
+      listHeaderShowCount={showCount}
       linkExtractor={linkExtractor}
       onSelectItem={handleSelectHotspot}
       isLoading={isLoading}

--- a/components/Widgets/RewardsTrendWidget.js
+++ b/components/Widgets/RewardsTrendWidget.js
@@ -234,7 +234,7 @@ const RewardsTrendWidget = ({
       if (dataPointTimePeriod === 'day') {
         return format(offsetDate, 'MMM d')
       }
-      return `${format(offsetDate, 'MMM d hh:mm')} UTC`
+      return `${format(offsetDate, 'MMM d hh:mma')} UTC`
     })
 
     return {

--- a/components/Widgets/RewardsTrendWidget.js
+++ b/components/Widgets/RewardsTrendWidget.js
@@ -234,7 +234,7 @@ const RewardsTrendWidget = ({
       if (dataPointTimePeriod === 'day') {
         return format(offsetDate, 'MMM d')
       }
-      return `${format(offsetDate, 'MMM d hh:mma')} UTC`
+      return `${format(offsetDate, 'MMM d HH:mm')} UTC`
     })
 
     return {


### PR DESCRIPTION
the count was erroneously showing up on /hotspots/latest and /city/:cityid/hotspots, and it only works when the count is known, i.e., it's not loaded with infinite-scroll. so in infinite-scroll lists, it was showing the number of hotspots that had been fetched with infinite scroll (20, 40, 60, ...)

this PR makes the hotspot list display without the count by default:
| currently | this PR |
| ------- | ------- |
| <img width="479" alt="Screen Shot 2022-01-05 at 3 50 57 PM" src="https://user-images.githubusercontent.com/10648471/148288057-821b8321-7ddc-4179-8585-425ebf33b191.png"> | <img width="481" alt="Screen Shot 2022-01-05 at 3 52 49 PM" src="https://user-images.githubusercontent.com/10648471/148288061-145c699e-d6d0-4edd-aa7d-77a03b7529a4.png">

and it'll still show the count for the Hotspots tab of an account page (the purpose it was originally added for, useful on accounts with large numbers of hotspots):
<img width="430" alt="Screen Shot 2022-01-05 at 3 53 09 PM" src="https://user-images.githubusercontent.com/10648471/148288064-b02c81c5-0623-41c0-91a9-520f0b68973d.png">
