### PR TITLE
Make measuring icon show up again

### DIFF
--- a/components/Icons/MeasuringIcon.js
+++ b/components/Icons/MeasuringIcon.js
@@ -1,12 +1,7 @@
-import classNames from 'classnames'
-
 const MeasuringIcon = ({ active, className }) => {
   return (
     <svg
-      className={classNames('stroke-current', className, {
-        'text-white': active,
-        'text-black': !active,
-      })}
+      className={className}
       width="42"
       height="31"
       viewBox="0 0 42 31"
@@ -15,6 +10,7 @@ const MeasuringIcon = ({ active, className }) => {
     >
       <path
         d="M22.897 19.025L18.8644 12.0403M22.897 19.025L31.1649 14.2515M22.897 19.025L14.6291 23.7984M31.1649 14.2515L39.4328 9.47801L35.4002 2.49332M31.1649 14.2515L29.1323 10.7309M14.6291 23.7984L6.36123 28.5719L2.32861 21.5872M14.6291 23.7984L12.5965 20.2778"
+        stroke={active ? 'white' : 'black'}
         strokeWidth="3"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
the icon seems to have gotten deleted somehow (not sure how):
![Screen Shot 2022-04-08 at 9 25 50 AM](https://user-images.githubusercontent.com/10648471/162483195-b9d880f4-93af-48f8-8194-38782a4c0bd6.png)

so this PR adds it back:
![Screen Shot 2022-04-08 at 9 25 43 AM](https://user-images.githubusercontent.com/10648471/162483219-50903ee8-e8b9-4dd5-ae21-6d7492aa3d94.png)
