### PR TITLE
ensure hotspot details update when navigating forward and back

### DIFF
--- a/components/InfoBox/HotspotDetailsInfoBox.js
+++ b/components/InfoBox/HotspotDetailsInfoBox.js
@@ -36,7 +36,7 @@ const HotspotDetailsRoute = () => {
   } = useSelectedHotspot()
 
   useEffect(() => {
-    if (!hotspot) {
+    if (!hotspot || address !== hotspot.address) {
       selectHotspot(address)
     }
   }, [hotspot, address, selectHotspot])


### PR DESCRIPTION
Fixes the bug where you are on a hotspot page, and you search for a different hotspot using the search box, pressing browser-back or forward only changes the name but nothing else. The map doesn't reload and the rest of the stats tab does not reload.