### PR TITLE
Change "Sync Status" to "Status"

### DIFF
--- a/components/Widgets/StatusWidget.js
+++ b/components/Widgets/StatusWidget.js
@@ -50,7 +50,7 @@ const StatusWidget = ({ hotspot }) => {
 
   return (
     <Widget
-      title="Sync Status"
+      title="Status"
       value={value}
       subtitle={
         hotspot?.status?.timestamp && (


### PR DESCRIPTION
As light hotspots no longer sync with the blockchain, "Sync Status" is not a great label for this section. Since the statuses are now only 'Connected' or 'Offline', those should be self-explanatory enough to eliminate the need for a 'Status' qualifier.