### PR TITLE
Show new hotspot counts

### DIFF
--- a/components/InfoBox/Hotspots/StatisticsPane.js
+++ b/components/InfoBox/Hotspots/StatisticsPane.js
@@ -45,6 +45,26 @@ const StatisticsPane = () => {
         series={stats?.countriesCount}
         isLoading={!stats}
       />
+      <StatWidget
+        title="Data-Only Hotspots"
+        series={stats?.dataOnlyCount}
+        isLoading={!stats}
+      />
+      <StatWidget
+        title="Hotspots that have been Rewarded (24H)"
+        series={stats?.rewardedCount}
+        isLoading={!stats}
+      />
+      <StatWidget
+        title="Hotspots that have Witnessed (24H)"
+        series={stats?.witnessesCount}
+        isLoading={!stats}
+      />
+      <StatWidget
+        title="Hotspots that have Beaconed (24H)"
+        series={stats?.challengeesCount}
+        isLoading={!stats}
+      />
       <HotspotWidget title="Latest Hotspot" hotspot={latestHotspot} />
     </InfoBoxPaneContainer>
   )

--- a/components/InfoBox/Hotspots/StatisticsPane.js
+++ b/components/InfoBox/Hotspots/StatisticsPane.js
@@ -54,16 +54,19 @@ const StatisticsPane = () => {
         title="Hotspots that have been Rewarded (24H)"
         series={stats?.rewardedCount}
         isLoading={!stats}
+        changeInitial="second_last"
       />
       <StatWidget
         title="Hotspots that have Witnessed (24H)"
         series={stats?.witnessesCount}
         isLoading={!stats}
+        changeInitial="second_last"
       />
       <StatWidget
         title="Hotspots that have Beaconed (24H)"
         series={stats?.challengeesCount}
         isLoading={!stats}
+        changeInitial="second_last"
       />
       <HotspotWidget title="Latest Hotspot" hotspot={latestHotspot} />
     </InfoBoxPaneContainer>


### PR DESCRIPTION
re-enable new hotspot counts after fixes to the api

- Data only count from https://github.com/helium/explorer/pull/661
- Hotspots that have been Rewarded (24H)
- Hotspots that have been Witnessed (24H)
- Hotspots that have been Challenged (24H)