### PR TITLE
update title and label for txn rate pane

### DIFF
--- a/components/InfoBox/BlocksInfoPanes/BlockStatisticsPane.js
+++ b/components/InfoBox/BlocksInfoPanes/BlockStatisticsPane.js
@@ -41,10 +41,10 @@ const BlockStatisticsPane = () => {
   return (
     <InfoBoxPaneContainer>
       <TrendWidget
-        title="Transaction Rate"
+        title="Transaction Rate (24hr)"
         series={blocks?.txnRate}
         isLoading={!blocks}
-        periodLabel={'Last 100 Blocks'}
+        periodLabel={'31 days'}
       />
       <StatWidget
         title="Block Height"


### PR DESCRIPTION
The Transaction Rate chart on the Blocks page shows daily average transaction rate for the last 31 days however the label current says Last 100 Blocks. This PR changes that to be 31 days as well as adds "(24hr)" to the title to indicate the average period consistent with the election time chart.