### PR TITLE
[CoinGecko] Add backlink to CoinGecko website

### DIFF
--- a/components/Common/InfoTooltip.tsx
+++ b/components/Common/InfoTooltip.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const InfoTooltip: FC<Props> = ({ text, href }) => {
   return (
-    <div className="text-gray-600 text-sm cursor-pointer flex">
+    <div className="text-gray-600 text-sm cursor-pointer flex" onClick={e => e.stopPropagation()}>
       <MaybeLink href={href}>
         <Tooltip title={text}>
           <InfoCircleOutlined />

--- a/components/InfoBox/MarketInfoBox.js
+++ b/components/InfoBox/MarketInfoBox.js
@@ -46,7 +46,7 @@ const MarketInfoBox = () => {
             />
             <Widget
               title="Market Price"
-              tooltip="Based on data provided by CoinGecko"
+              tooltip={<span>Based on data provided by <a target="_blank" rel="noreferrer" href="https://www.coingecko.com/en/coins/helium">CoinGecko</a></span>}
               value={<Currency value={market?.price} />}
               change={round(market?.priceChange, 2)}
               changeSuffix="%"
@@ -54,7 +54,7 @@ const MarketInfoBox = () => {
             />
             <Widget
               title="Market Cap"
-              tooltip="Based on data provided by CoinGecko"
+              tooltip={<span>Based on data provided by <a target="_blank" rel="noreferrer" href="https://www.coingecko.com/en/coins/helium">CoinGecko</a></span>}
               value={
                 <Currency
                   value={market?.price * stats?.circulatingSupply}

--- a/components/InfoBox/OverviewInfoBox.js
+++ b/components/InfoBox/OverviewInfoBox.js
@@ -62,7 +62,7 @@ const OverviewInfoBox = () => {
         />
         <Widget
           title="Market Price"
-          tooltip="Based on data provided by CoinGecko"
+          tooltip={<span>Based on data provided by <a target="_blank" rel="noreferrer" href="https://www.coingecko.com/en/coins/helium">CoinGecko</a></span>}
           value={<Currency value={market?.price} />}
           change={round(market?.priceChange, 2)}
           changeSuffix="%"


### PR DESCRIPTION
# Overview
Hello there! I'm Ervin from CoinGecko. Recently, our team has reached out to you to implement backlinks on the Helium Blockchain Explorer. This PR is an implementation of those requests. Please let me know if you need me to verify my identity, or if you require any thing else from my end. I would be happy to provide you with any information you require!

# Description
Adds backlinks to CoinGecko.com website on several tooltips.

# Changes
- Add backlinks to CoinGecko.com website `https://www.coingecko.com/en/coins/helium` on `CoinGecko` text.
  - Market Price widget card (`MarketInfoBox` and `OverviewInfoBox`) 
  - Market Cap widget card (`MarketInfoBox`)
- Stops event propagation in `InfoTooltip` component to enable links on the tooltip popup to be clicked.

# Screenshots & Recordings

| Description | Image/Recording |
| --- | --- |
| On the main Overview page (`/`) | <img width="480" alt="image" src="https://user-images.githubusercontent.com/88306776/182780724-2e879709-9fe8-411c-9418-d44e37d45e18.png"> |
| On the Market page (`/market`) | <img width="478" alt="image" src="https://user-images.githubusercontent.com/88306776/182780689-914c385d-73bf-416a-80ba-75af949319e4.png"> |
| Clicking the tooltip or its text on the main Overview page does not redirect to the Market page | ![chrome-capture-2022-7-4](https://user-images.githubusercontent.com/88306776/182781763-392612c9-91e1-42a1-b74a-9002b7702dcd.gif) |


