### PR TITLE
radio rewards bugs

### DIFF
--- a/data/rewards.js
+++ b/data/rewards.js
@@ -1,4 +1,4 @@
-import { format, getUnixTime, sub } from 'date-fns'
+import { getUnixTime, sub } from 'date-fns'
 import useSWR from 'swr'
 import client, { TAKE_MAX } from './client'
 import { fetchApi } from '../hooks/useApi'

--- a/data/rewards.js
+++ b/data/rewards.js
@@ -14,6 +14,19 @@ const TARGET_PRODUCTION = {
   [NETWORK_DATES[1]]: 5000000 / 2,
 }
 
+const getUTCTimeStamp = (date) => {
+  const year = date.getUTCFullYear()
+  const month = (date.getUTCMonth() + 1).toLocaleString('en-US', {
+    minimumIntegerDigits: 2,
+    useGrouping: false,
+  })
+  const day = date.getUTCDate().toLocaleString('en-US', {
+    minimumIntegerDigits: 2,
+    useGrouping: false,
+  })
+  return `${year}-${month}-${day}`
+}
+
 const getTargetProduction = (timestamp) => {
   const unixTimestamp = getUnixTime(new Date(timestamp))
   if (unixTimestamp >= NETWORK_DATES[1]) {
@@ -50,15 +63,16 @@ export const getHotspotRadioRewardsBuckets = async (address, numBack) => {
   if (!address) return
 
   const now = new Date()
-  now.setUTCHours(0, 0, 0, 0)
-  const maxTime = format(now, 'yyyy-MM-dd')
-  const minTime = format(sub(now, { days: numBack - 1 }), 'yyyy-MM-dd')
+  const start = sub(now, { days: 1 }) // previous day
+  const end = sub(now, { days: numBack })
+
+  console.log(getUTCTimeStamp(start), getUTCTimeStamp(end))
 
   const rewards = await fetchApi('v1')(
     `/cell/hotspots/${address}/rewards?` +
       qs.stringify({
-        max_date: maxTime,
-        min_date: minTime,
+        max_date: getUTCTimeStamp(start),
+        min_date: getUTCTimeStamp(end),
       }),
   )
   return rewards.reverse()
@@ -72,15 +86,14 @@ export const getRadioRewardsBuckets = async (
   if (!address || !radioAddress) return
 
   const now = new Date()
-  now.setUTCHours(0, 0, 0, 0)
-  const maxTime = format(now, 'yyyy-MM-dd')
-  const minTime = format(sub(now, { days: numBack - 1 }), 'yyyy-MM-dd')
+  const start = sub(now, { days: 1 }) // previous day
+  const end = sub(now, { days: numBack })
 
   const rewards = await fetchApi('v1')(
     `/cell/hotspots/${address}/cells/${radioAddress}/rewards?` +
       qs.stringify({
-        max_date: maxTime,
-        min_date: minTime,
+        max_date: getUTCTimeStamp(start),
+        min_date: getUTCTimeStamp(end),
       }),
   )
   return rewards.reverse()

--- a/data/rewards.js
+++ b/data/rewards.js
@@ -62,11 +62,10 @@ export const getHotspotRewardsBuckets = async (address, numBack, bucket) => {
 export const getHotspotRadioRewardsBuckets = async (address, numBack) => {
   if (!address) return
 
-  const now = new Date()
-  const start = sub(now, { days: 1 }) // previous day
-  const end = sub(now, { days: numBack })
-
-  console.log(getUTCTimeStamp(start), getUTCTimeStamp(end))
+  // set base time back 2 hours for reward processing time
+  const baseTime = sub(new Date(), { hours: 2 })
+  const start = sub(baseTime, { days: 1 })
+  const end = sub(baseTime, { days: numBack })
 
   const rewards = await fetchApi('v1')(
     `/cell/hotspots/${address}/rewards?` +
@@ -85,9 +84,10 @@ export const getRadioRewardsBuckets = async (
 ) => {
   if (!address || !radioAddress) return
 
-  const now = new Date()
-  const start = sub(now, { days: 1 }) // previous day
-  const end = sub(now, { days: numBack })
+  // set base time back 2 hours for reward processing time
+  const baseTime = sub(new Date(), { hours: 2 })
+  const start = sub(baseTime, { days: 1 })
+  const end = sub(baseTime, { days: numBack })
 
   const rewards = await fetchApi('v1')(
     `/cell/hotspots/${address}/cells/${radioAddress}/rewards?` +


### PR DESCRIPTION
- use correct utc time for radio reward calculations in all timezones (some timezones were getting wrong date range)

TODO:
- show speed test failures for radios that have old speed test data
- A minimum of two and maximum of six Speed Tests are required in the previous 48 hours to calculate a Moving average results for each download, upload, and latency, after which a new series of Speed Test results must be collected before a Moving Average can be calculated.

It was decided to fix outdated speed tests at a later date. We can merge this with the timezone fixes now.